### PR TITLE
Fix Help window display issue

### DIFF
--- a/src/main/resources/view/HelpWindow.fxml
+++ b/src/main/resources/view/HelpWindow.fxml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+<?import java.net.*?>
+<?import javafx.geometry.*?>
 <?import javafx.scene.*?>
 <?import javafx.scene.control.*?>
 <?import javafx.scene.image.*?>
 <?import javafx.scene.layout.*?>
 <?import javafx.stage.*?>
 
-<?import javafx.geometry.Insets?>
-<?import java.net.URL?>
-<fx:root resizable="false" title="Help" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/11.0.1" xmlns:fx="http://javafx.com/fxml/1">
+<fx:root resizable="false" title="Help" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
   <icons>
     <Image url="@/images/help_icon.png" />
   </icons>
@@ -18,17 +18,17 @@
         <URL value="@Fonts.css" />
         <URL value="@HelpWindow.css" />
       </stylesheets>
-      <VBox prefHeight="353.0" prefWidth="469.0">
+      <VBox prefHeight="380.0" prefWidth="470.0">
         <children>
           <Pane prefHeight="345.0" prefWidth="469.0">
             <children>
-              <TextArea fx:id="featureList" editable="false" layoutY="-6.0" prefHeight="365.0" prefWidth="470.0" text="Feature List" wrapText="true" />
+              <TextArea fx:id="featureList" editable="false" prefHeight="384.0" prefWidth="469.0" text="Feature List" wrapText="true" />
             </children>
           </Pane>
 
-          <HBox alignment="CENTER" prefHeight="99.0" prefWidth="469.0">
+          <HBox alignment="CENTER" prefHeight="141.0" prefWidth="470.0">
             <children>
-              <Label fx:id="helpMessage" prefHeight="34.0" prefWidth="252.0" text="Label" wrapText="true">
+              <Label fx:id="helpMessage" prefHeight="78.0" prefWidth="369.0" text="Label" wrapText="true">
                 <HBox.margin>
                   <Insets right="5.0" />
                 </HBox.margin>


### PR DESCRIPTION
Make the label box larger so that the URL can be fully displayed: 
<img width="352" alt="1" src="https://user-images.githubusercontent.com/77187494/136665384-1a7e7cee-6b3e-4501-9b6f-c511be3e153c.png">

