### PR TITLE
Remove CI on push

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,6 +1,6 @@
 name: Java CI
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
Remove CI checks on push to speed up checks. Am assuming there will be no failures from pushing since there is already a check when commits are made in a PR.