### PR TITLE
Relax restrictions on cid, sid and email arguments

### DIFF
--- a/src/main/java/seedu/programmer/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/programmer/logic/parser/ParserUtil.java
@@ -12,8 +12,6 @@ import seedu.programmer.model.student.Email;
 import seedu.programmer.model.student.Name;
 import seedu.programmer.model.student.StudentId;
 
-import java.util.Locale;
-
 /**
  * Contains utility methods used for parsing strings in the various *Parser classes.
  */


### PR DESCRIPTION
fixes #273 

The following restrictions are being relaxed when parsing Class ID, Student ID and Email arguments:
- User can key in `-cid b01` to indicate class of `B01`
- User can key in `-sid a1234567x` to indicate student ID of `A1234567X`
- User can key in `-email E1234567@u.nus.edu` to indicate email of `e1234567@u.nus.edu`