### PR TITLE
Improve error messages for Edit

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -18,7 +18,7 @@ If you are familiar with Unix commands, this is definitely for you!
         3. [Exit: `exit`](#exit)
     2. [Data Features](#data-features)
         1. [Fill Sample Data: `fill`](#fill-sample-data)
-        2. [Purge All Data: `purge`](#purge-all-data)
+        2. [Purge All Data: ``](#-all-data)
         3. [Download Data: `download`](#download-data)
         4. [Upload Data: `upload`](#upload-data)
     3. [Student Features](#student-features)

--- a/src/main/java/seedu/programmer/logic/commands/EditLabCommand.java
+++ b/src/main/java/seedu/programmer/logic/commands/EditLabCommand.java
@@ -32,11 +32,11 @@ public class EditLabCommand extends Command {
 
     public static final String MESSAGE_EDIT_LAB_SUCCESS = "Updated %1$s!";
 
-    public static final String LAB_SCORE_MESSAGE_CONSTRAINTS = "The lab total score should be a positive value.";
+    public static final String MESSAGE_SCORE_SHOULD_BE_POSITIVE = "The lab total score %f should be a positive value.";
 
-    public static final String LAB_NEW_NUM_CONSTRAINTS = "The lab number already exists.";
+    public static final String MESSAGE_LAB_ALREADY_EXISTS = "Lab %d already exists.";
 
-    public static final String LAB_NUM_CONSTRAINTS = "The lab number doesn't exist.";
+    public static final String MESSAGE_LAB_NOT_EXISTS = "Lab %d doesn't exist.";
 
     private final int newLabNum;
     private final Double total;
@@ -75,14 +75,14 @@ public class EditLabCommand extends Command {
         List<Student> lastShownList = model.getFilteredStudentList();
         Lab newLab = new Lab(newLabNum);
         if (lastShownList.get(0).getLabList().contains(newLab)) {
-            throw new CommandException(LAB_NEW_NUM_CONSTRAINTS);
+            throw new CommandException(String.format(MESSAGE_LAB_ALREADY_EXISTS, newLab.getLabNum()));
         }
         for (Student std : lastShownList) {
             Student editedStd = std;
             if (total != null && total < 0.0) {
-                throw new CommandException(LAB_SCORE_MESSAGE_CONSTRAINTS);
+                throw new CommandException(String.format(MESSAGE_SCORE_SHOULD_BE_POSITIVE, total));
             } else if (!std.getLabList().contains(original)) {
-                throw new CommandException(LAB_NUM_CONSTRAINTS);
+                throw new CommandException(String.format(MESSAGE_LAB_NOT_EXISTS, original.getLabNum()));
             } else {
                 editedStd.editLabInfo(original, newLabNum, total);
                 model.setStudent(std, editedStd);
@@ -104,7 +104,4 @@ public class EditLabCommand extends Command {
                 || (other instanceof EditLabCommand// instanceof handles nulls
                 && original.equals(((EditLabCommand) other).original)); // state check
     }
-
-
 }
-

--- a/src/test/java/seedu/programmer/logic/commands/EditLabCommandTest.java
+++ b/src/test/java/seedu/programmer/logic/commands/EditLabCommandTest.java
@@ -50,21 +50,21 @@ public class EditLabCommandTest {
     }
 
     @Test
-    public void execute_labTitleDoesNotExist_throwsCommandException() throws Exception {
+    public void execute_labTitleDoesNotExist_throwsCommandException() {
         Lab labToEdit = new Lab(10);
         EditLabCommand editLabCommand = new EditLabCommand(labToEdit, newLabNum);
 
-        String expectedMessage = String.format(EditLabCommand.LAB_NUM_CONSTRAINTS, labToEdit);
+        String expectedMessage = String.format(EditLabCommand.MESSAGE_LAB_NOT_EXISTS, labToEdit.getLabNum());
 
         assertCommandFailure(editLabCommand, model, expectedMessage);
     }
 
     @Test
-    public void execute_newlabTitleAlreadyExists_throwsCommandException() throws Exception {
+    public void execute_newlabTitleAlreadyExists_throwsCommandException() {
         Lab labToEdit = getTypicalLabList().get(NUMBER_FIRST_LAB);
-        EditLabCommand editLabCommand = new EditLabCommand(labToEdit, 2);
+        EditLabCommand editLabCommand = new EditLabCommand(labToEdit, 1);
 
-        String expectedMessage = String.format(EditLabCommand.LAB_NEW_NUM_CONSTRAINTS, labToEdit);
+        String expectedMessage = String.format(EditLabCommand.MESSAGE_LAB_ALREADY_EXISTS, labToEdit.getLabNum());
 
         assertCommandFailure(editLabCommand, model, expectedMessage);
     }

--- a/src/test/java/seedu/programmer/testutil/TypicalLabs.java
+++ b/src/test/java/seedu/programmer/testutil/TypicalLabs.java
@@ -24,9 +24,7 @@ public class TypicalLabs {
      */
     public static ObservableList<Lab> getTypicalLabList() {
         ObservableList<Lab> labResultList = FXCollections.observableArrayList();
-        for (Lab lab : getTypicalLabs()) {
-            labResultList.add(lab);
-        }
+        labResultList.addAll(getTypicalLabs());
         return labResultList;
     }
 


### PR DESCRIPTION
Fix #355:

- Rename variables to be more intuitive
- Format error messages with user input