### PR TITLE
Fix bug in command history

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -59,6 +59,9 @@ If you are familiar with Unix commands, this is definitely for you!
 
 **Notes about the command format (Unix Command Syntax):**
 - Similar to Unix CLI, the up and down arrow keys can be used to navigate the history of commands executed.
+  - Up Arrow Key: Navigate to an older command.
+  - Down Arrow Key: Navigate to a more recent command.
+  - Command will only be stored after `Enter` has been pressed.
 - Flags will be used to specify different options for the commands. For example, the `-sid` flag can be used to specify
   a student's student ID.
 - Parameters can be in any order. <br> e.g. if the command specifies `-n NAME -sid STUDENT_ID`

--- a/src/main/java/seedu/programmer/ui/CommandHistory.java
+++ b/src/main/java/seedu/programmer/ui/CommandHistory.java
@@ -42,10 +42,12 @@ public class CommandHistory {
             logger.info("There is no command history.");
             return DEFAULT_COMMAND;
         }
-        String result = commandHistory.get(counter);
+
         if (!isCounterAtFirst()) {
             counter--;
         }
+        String result = commandHistory.get(counter);
+
         logger.info("Previous Command retrieved: " + result);
         return result;
     }
@@ -61,10 +63,11 @@ public class CommandHistory {
             logger.info("There is no command history.");
             return DEFAULT_COMMAND;
         }
-        String result = commandHistory.get(counter);
         if (!isCounterAtLast()) {
             counter++;
         }
+        String result = commandHistory.get(counter);
+
         logger.info("Next Command retrieved: " + result);
         return result;
     }
@@ -91,13 +94,13 @@ public class CommandHistory {
         return commandHistory.size() == 0;
     }
 
-    private void resetCounterToLast() {
-        counter = commandHistory.size() - 1;
+    private void resetCounterToDefault() {
+        counter = commandHistory.size();
     }
 
     private void addCommandToHistory(String command) {
         commandHistory.add(command);
-        resetCounterToLast();
+        resetCounterToDefault();
     }
 
     private boolean isCounterAtLast() {

--- a/src/main/java/seedu/programmer/ui/CommandHistory.java
+++ b/src/main/java/seedu/programmer/ui/CommandHistory.java
@@ -8,7 +8,6 @@ import seedu.programmer.commons.core.LogsCenter;
 
 public class CommandHistory {
     static final String DEFAULT_COMMAND = "";
-    private static final int INITIAL_COUNTER_VALUE = -1;
 
     private final Logger logger = LogsCenter.getLogger(getClass());
     private List<String> commandHistory;
@@ -19,7 +18,7 @@ public class CommandHistory {
      */
     public CommandHistory() {
         commandHistory = new ArrayList<>();
-        counter = INITIAL_COUNTER_VALUE;
+        counter = commandHistory.size();
     }
 
     /**
@@ -32,7 +31,7 @@ public class CommandHistory {
     }
 
     /**
-     * Returns the next most recent entered command according to the {@code counter} pointer.
+     * Returns the next most recently entered command according to the {@code counter} pointer.
      * Returns the {@code DEFAULT_COMMAND} if the {@code commandHistory} is empty.
      * Returns the least recent command if the {@code counter} is already pointer at the oldest command.
      * @return The string of the next most recent entered command.
@@ -63,6 +62,10 @@ public class CommandHistory {
             logger.info("There is no command history.");
             return DEFAULT_COMMAND;
         }
+        if (isCounterAtDefault()) {
+            logger.info("Previous command has not been executed before. Empty command returned.");
+            return DEFAULT_COMMAND;
+        }
         if (!isCounterAtLast()) {
             counter++;
         }
@@ -90,6 +93,9 @@ public class CommandHistory {
                 && counter == e.counter;
     }
 
+    private boolean isCounterAtDefault() {
+        return counter == commandHistory.size();
+    }
     private boolean isCommandHistoryEmpty() {
         return commandHistory.size() == 0;
     }

--- a/src/test/java/seedu/programmer/ui/CommandHistoryTest.java
+++ b/src/test/java/seedu/programmer/ui/CommandHistoryTest.java
@@ -72,8 +72,8 @@ public class CommandHistoryTest {
         commandHistory.add("two");
         commandHistory.add("three");
 
-        // getPrevCommand has not been executed --> expect the latest executed command
-        assertEquals(commandHistory.getNextCommand(), "three");
+        // getPrevCommand has not been executed --> expect the default empty command
+        assertEquals(commandHistory.getNextCommand(), "");
 
         // Execute getPrevCommand to the oldest command
         commandHistory.getPrevCommand();
@@ -81,9 +81,9 @@ public class CommandHistoryTest {
         commandHistory.getPrevCommand();
 
         // Retrieve the next command
-        assertEquals(commandHistory.getNextCommand(), "one");
-        // Retrieve the next command
         assertEquals(commandHistory.getNextCommand(), "two");
+        // Retrieve the next command
+        assertEquals(commandHistory.getNextCommand(), "three");
     }
 
     @Test


### PR DESCRIPTION
fixes #311 

Navigating command history no longer require double keypress when at the oldest or most recent command.

To be done:
1. Discuss what to be returned when next command pressed but previous command has never been executed before.
2. Update UG to be clear to users on how Command History navigation works.
3. Address #317 in UserGuide as well