### PR TITLE
Fix #329: Overflowing dashboard

### DIFF
--- a/src/main/java/seedu/programmer/ui/DashboardWindow.java
+++ b/src/main/java/seedu/programmer/ui/DashboardWindow.java
@@ -7,7 +7,9 @@ import java.util.logging.Logger;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
+import javafx.scene.control.ScrollPane;
 import javafx.scene.layout.StackPane;
+import javafx.scene.layout.VBox;
 import javafx.stage.Stage;
 import seedu.programmer.commons.core.LogsCenter;
 import seedu.programmer.logic.Logic;
@@ -31,7 +33,10 @@ public class DashboardWindow extends PopupWindow {
     private StackPane overallStatsPlaceholder;
 
     @FXML
-    private StackPane labsMarkedList;
+    private ScrollPane labsMarkedList;
+
+    @FXML
+    private VBox labVBox;
 
 
     /**
@@ -73,12 +78,12 @@ public class DashboardWindow extends PopupWindow {
     }
 
     private void fillLabsMarked() {
-        labsMarkedList.getChildren().clear();
+        labVBox.getChildren().clear();
         String labsMarked = formatLabsToDisplay(labsUnmarkedMap);
         Label labsLabel = new Label(labsMarked);
         labsLabel.getStylesheets().add("view/Dashboard.css");
         labsLabel.getStyleClass().add("labs-marked");
-        labsMarkedList.getChildren().add(labsLabel);
+        labVBox.getChildren().add(labsLabel);
     }
 
     /**

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -136,6 +136,11 @@
      -fx-background-color: derive(#1d1d1d, 20%);
 }
 
+.split-pane *.split-pane-divider {
+    -fx-padding: 1 0 1 0;
+    visibility: hidden;
+}
+
 .pane-with-border {
      -fx-background-color: derive(#1d1d1d, 20%);
      -fx-border-color: derive(#1d1d1d, 10%);

--- a/src/main/resources/view/DashboardWindow.fxml
+++ b/src/main/resources/view/DashboardWindow.fxml
@@ -3,17 +3,14 @@
 <?import java.net.URL?>
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.Scene?>
-<?import javafx.scene.control.ScrollBar?>
 <?import javafx.scene.control.SplitPane?>
-<?import javafx.scene.effect.SepiaTone?>
 <?import javafx.scene.image.Image?>
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
 <?import javafx.stage.Stage?>
 
 <?import javafx.scene.control.ScrollPane?>
-<?import javafx.scene.control.Label?>
-<fx:root minHeight="600" minWidth="450" title="Dashboard" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/16" xmlns:fx="http://javafx.com/fxml/1">
+<fx:root minHeight="600" minWidth="450" title="Dashboard" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
   <icons>
     <Image url="@/images/programmer_error.png" />
   </icons>

--- a/src/main/resources/view/DashboardWindow.fxml
+++ b/src/main/resources/view/DashboardWindow.fxml
@@ -1,14 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import java.net.*?>
-<?import javafx.geometry.*?>
-<?import javafx.scene.*?>
-<?import javafx.scene.control.*?>
-<?import javafx.scene.image.*?>
-<?import javafx.scene.layout.*?>
-<?import javafx.stage.*?>
+<?import java.net.URL?>
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.Scene?>
+<?import javafx.scene.control.ScrollBar?>
+<?import javafx.scene.control.SplitPane?>
+<?import javafx.scene.effect.SepiaTone?>
+<?import javafx.scene.image.Image?>
+<?import javafx.scene.layout.StackPane?>
+<?import javafx.scene.layout.VBox?>
+<?import javafx.stage.Stage?>
 
-<fx:root minHeight="600" minWidth="450" title="Dashboard" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
+<?import javafx.scene.control.ScrollPane?>
+<?import javafx.scene.control.Label?>
+<fx:root minHeight="600" minWidth="450" title="Dashboard" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/16" xmlns:fx="http://javafx.com/fxml/1">
   <icons>
     <Image url="@/images/programmer_error.png" />
   </icons>
@@ -21,21 +26,19 @@
       </stylesheets>
 
       <VBox>
-        <StackPane fx:id="overallStatsPlaceholder" styleClass="pane-with-border" VBox.vgrow="NEVER">
-          <padding>
-            <Insets bottom="5" left="10" right="10" top="5" />
-          </padding>
-        </StackPane>
-
-        <SplitPane dividerPositions="0.5" VBox.vgrow="ALWAYS">
-           <items>
-              <VBox fx:id="studentList" minWidth="340" prefWidth="340" styleClass="pane-with-border">
-                <padding>
-                  <Insets bottom="10" left="10" right="10" top="10" />
-                </padding>
-                <StackPane fx:id="labsMarkedList" VBox.vgrow="ALWAYS" />
-              </VBox>
-           </items>
+        <SplitPane dividerPositions="0.25" VBox.vgrow="NEVER" orientation="VERTICAL" centerShape="false">
+          <items>
+            <StackPane fx:id="overallStatsPlaceholder" styleClass="pane-with-border" VBox.vgrow="NEVER" minHeight="150" maxHeight="150">
+              <padding>
+                <Insets bottom="5" left="10" right="10" top="5" />
+              </padding>
+            </StackPane>
+            <ScrollPane fx:id="labsMarkedList" VBox.vgrow="ALWAYS" fitToWidth="true" >
+              <content>
+                <VBox prefWidth="200" alignment="center" fx:id="labVBox" styleClass="pane-with-border" />
+              </content>
+            </ScrollPane>
+          </items>
         </SplitPane>
       </VBox>
     </Scene>


### PR DESCRIPTION
- Add ScrollPane for unmarked labs
- Use SplitPane to separate ScrollPane from above StackPane
- Set SplitPane divider to be undraggable

![image](https://user-images.githubusercontent.com/40263305/139578480-113b003a-433a-4765-b8fa-845e1acce208.png)
