### PR TITLE
Fix tokenizer to ensure negative values are not parsed as flags

### DIFF
--- a/src/main/java/seedu/programmer/logic/parser/ArgumentTokenizer.java
+++ b/src/main/java/seedu/programmer/logic/parser/ArgumentTokenizer.java
@@ -62,7 +62,21 @@ public class ArgumentTokenizer {
         if (str.length() == 0) {
             return false;
         }
-        return Character.toString(str.charAt(0)).equals(PREFIX_SYMBOL.getPrefix());
+        String firstCharacter = Character.toString(str.charAt(0));
+        if (!firstCharacter.equals(PREFIX_SYMBOL.getPrefix())) {
+            return false;
+        }
+        String restOfString = str.substring(1);
+
+        if (isValidNumericalInput(restOfString)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static boolean isValidNumericalInput(String restOfString) {
+        return restOfString.matches("^(0|[1-9]\\d*)?(\\.\\d+)?(?<=\\d)$");
     }
 
     /**

--- a/src/test/java/seedu/programmer/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/programmer/logic/parser/EditCommandParserTest.java
@@ -2,7 +2,6 @@
 package seedu.programmer.logic.parser;
 
 import static seedu.programmer.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.programmer.commons.core.Messages.MESSAGE_UNKNOWN_ARGUMENT_FLAG;
 import static seedu.programmer.logic.commands.CommandTestUtil.CLASS_ID_DESC_AMY;
 import static seedu.programmer.logic.commands.CommandTestUtil.CLASS_ID_DESC_BOB;
 import static seedu.programmer.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
@@ -61,9 +60,7 @@ public class EditCommandParserTest {
     @Test
     public void parse_invalidPreamble_failure() {
         // negative index
-        assertParseFailure(parser,
-                "-5" + NAME_DESC_AMY,
-                String.format(MESSAGE_UNKNOWN_ARGUMENT_FLAG, "[-5]", EditCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "-5" + NAME_DESC_AMY, MESSAGE_INVALID_FORMAT);
 
         // zero index
         assertParseFailure(parser, "0" + NAME_DESC_AMY, MESSAGE_INVALID_FORMAT);

--- a/src/test/java/seedu/programmer/logic/parser/EditLabCommandParserTest.java
+++ b/src/test/java/seedu/programmer/logic/parser/EditLabCommandParserTest.java
@@ -3,7 +3,6 @@ package seedu.programmer.logic.parser;
 
 import static seedu.programmer.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.programmer.commons.core.Messages.MESSAGE_MISSING_ARGUMENT;
-import static seedu.programmer.commons.core.Messages.MESSAGE_UNKNOWN_ARGUMENT_FLAG;
 import static seedu.programmer.logic.commands.CommandTestUtil.INVALID_LAB_NUM;
 import static seedu.programmer.logic.commands.CommandTestUtil.INVALID_LAB_TOTAL;
 import static seedu.programmer.logic.commands.CommandTestUtil.INVALID_NEW_LAB_NUM;
@@ -44,17 +43,17 @@ public class EditLabCommandParserTest {
         // invalid labNum
         assertParseFailure(parser,
                 INVALID_LAB_NUM + NEW_LAB_NUM + LAB_TOTAL2,
-                String.format(MESSAGE_UNKNOWN_ARGUMENT_FLAG, "[-1]", EditLabCommand.MESSAGE_USAGE));
+                MESSAGE_INVALID_FORMAT);
 
         // invalid newLabNum
         assertParseFailure(parser,
                 LAB_NUM + INVALID_NEW_LAB_NUM + LAB_TOTAL2,
-                String.format(MESSAGE_UNKNOWN_ARGUMENT_FLAG, "[-2]", EditLabCommand.MESSAGE_USAGE));
+                MESSAGE_INVALID_FORMAT);
 
         // invalid labTotal
         assertParseFailure(parser,
                 LAB_NUM + NEW_LAB_NUM + INVALID_LAB_TOTAL,
-                String.format(MESSAGE_UNKNOWN_ARGUMENT_FLAG, "[-10.0]", EditLabCommand.MESSAGE_USAGE));
+                MESSAGE_INVALID_FORMAT);
     }
 
     @Test


### PR DESCRIPTION
fixes #365 

Fixes the internal implementation of tokeniser to avoid recognising negative floating number and integers as a flag argument

Future fixes of how the individual command handles negative inputs will be dealt with in a separate PR.