### PR TITLE
TextField in CommandBox will remain the same whenever invalid keypress detected

### DIFF
--- a/src/main/java/seedu/programmer/ui/CommandBox.java
+++ b/src/main/java/seedu/programmer/ui/CommandBox.java
@@ -1,5 +1,6 @@
 package seedu.programmer.ui;
 
+import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.TextField;
 import javafx.scene.input.KeyCode;
@@ -8,6 +9,7 @@ import javafx.scene.layout.Region;
 import seedu.programmer.logic.commands.CommandResult;
 import seedu.programmer.logic.commands.exceptions.CommandException;
 import seedu.programmer.logic.parser.exceptions.ParseException;
+import seedu.programmer.ui.exceptions.CommandHistoryException;
 
 /**
  * The UI component that is responsible for receiving user command inputs.
@@ -48,7 +50,7 @@ public class CommandBox extends UiPart<Region> {
             commandExecutor.execute(commandText);
             commandTextField.setText("");
         } catch (CommandException | ParseException e) {
-            commandTextField.setText("");
+            setStyleToIndicateCommandFailure();
         }
     }
 
@@ -58,15 +60,22 @@ public class CommandBox extends UiPart<Region> {
      */
     @FXML
     private void handleKeyPressed(KeyEvent event) {
-        if (event.getCode() == KeyCode.UP) {
-            commandTextField.setText(commandHistory.getPrevCommand());
-        } else if (event.getCode() == KeyCode.DOWN) {
-            commandTextField.setText(commandHistory.getNextCommand());
-        } else {
-            return;
+        try {
+            if (event.getCode() == KeyCode.UP) {
+                commandTextField.setText(commandHistory.getPrevCommand());
+            }
+
+            if (event.getCode() == KeyCode.DOWN) {
+                commandTextField.setText(commandHistory.getNextCommand());
+            }
+
+//            event.consume(); // Consume Event
+        } catch (CommandHistoryException e) {
+            System.out.println("hi");
+        } finally {
+            commandTextField.end();
+
         }
-        commandTextField.end();
-        event.consume(); // Consume Event`
     }
 
     /**
@@ -74,6 +83,19 @@ public class CommandBox extends UiPart<Region> {
      */
     private void setStyleToDefault() {
         commandTextField.getStyleClass().remove(ERROR_STYLE_CLASS);
+    }
+
+    /**
+     * Sets the command box style to indicate a failed command.
+     */
+    private void setStyleToIndicateCommandFailure() {
+        ObservableList<String> styleClass = commandTextField.getStyleClass();
+
+        if (styleClass.contains(ERROR_STYLE_CLASS)) {
+            return;
+        }
+
+        styleClass.add(ERROR_STYLE_CLASS);
     }
 
     /**

--- a/src/main/java/seedu/programmer/ui/CommandBox.java
+++ b/src/main/java/seedu/programmer/ui/CommandBox.java
@@ -63,18 +63,17 @@ public class CommandBox extends UiPart<Region> {
         try {
             if (event.getCode() == KeyCode.UP) {
                 commandTextField.setText(commandHistory.getPrevCommand());
-            }
-
-            if (event.getCode() == KeyCode.DOWN) {
+            } else if (event.getCode() == KeyCode.DOWN) {
                 commandTextField.setText(commandHistory.getNextCommand());
+            } else {
+                return;
             }
-
-//            event.consume(); // Consume Event
-        } catch (CommandHistoryException e) {
-            System.out.println("hi");
-        } finally {
+            setStyleToDefault();
             commandTextField.end();
-
+            event.consume(); // Consume Event
+        } catch (CommandHistoryException e) {
+            commandTextField.end();
+            return;
         }
     }
 

--- a/src/main/java/seedu/programmer/ui/CommandBox.java
+++ b/src/main/java/seedu/programmer/ui/CommandBox.java
@@ -1,6 +1,5 @@
 package seedu.programmer.ui;
 
-import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.TextField;
 import javafx.scene.input.KeyCode;
@@ -49,7 +48,7 @@ public class CommandBox extends UiPart<Region> {
             commandExecutor.execute(commandText);
             commandTextField.setText("");
         } catch (CommandException | ParseException e) {
-            setStyleToIndicateCommandFailure();
+            commandTextField.setText("");
         }
     }
 
@@ -75,19 +74,6 @@ public class CommandBox extends UiPart<Region> {
      */
     private void setStyleToDefault() {
         commandTextField.getStyleClass().remove(ERROR_STYLE_CLASS);
-    }
-
-    /**
-     * Sets the command box style to indicate a failed command.
-     */
-    private void setStyleToIndicateCommandFailure() {
-        ObservableList<String> styleClass = commandTextField.getStyleClass();
-
-        if (styleClass.contains(ERROR_STYLE_CLASS)) {
-            return;
-        }
-
-        styleClass.add(ERROR_STYLE_CLASS);
     }
 
     /**

--- a/src/main/java/seedu/programmer/ui/CommandHistory.java
+++ b/src/main/java/seedu/programmer/ui/CommandHistory.java
@@ -8,8 +8,6 @@ import seedu.programmer.commons.core.LogsCenter;
 import seedu.programmer.ui.exceptions.CommandHistoryException;
 
 public class CommandHistory {
-    static final String DEFAULT_COMMAND = "";
-
     private final Logger logger = LogsCenter.getLogger(getClass());
     private List<String> commandHistory;
     private int counter;
@@ -24,7 +22,6 @@ public class CommandHistory {
 
     /**
      * Adds the {@code command} to the {@code commandHistory}.
-     * {@code counter} resets itself to point to the most recently added command to {@code commandHistory}.
      * @param command The string to be added to the history of commands.
      */
     public void add(String command) {
@@ -33,9 +30,9 @@ public class CommandHistory {
 
     /**
      * Returns the next most recently entered command according to the {@code counter} pointer.
-     * Returns the {@code DEFAULT_COMMAND} if the {@code commandHistory} is empty.
      * Returns the least recent command if the {@code counter} is already pointer at the oldest command.
      * @return The string of the next most recent entered command.
+     * @throws CommandHistoryException is thrown when the command history is empty.
      */
     public String getPrevCommand() throws CommandHistoryException {
         if (isCommandHistoryEmpty()) {
@@ -54,9 +51,10 @@ public class CommandHistory {
 
     /**
      * Returns the next least recent entered command according to the {@code counter} pointer.
-     * Returns the {@code DEFAULT_COMMAND} if the {@code commandHistory} is empty.
      * Returns the most recent command if the {@code counter} is already pointer at the latest command.
      * @return The string of the next least recent entered command.
+     * @throws CommandHistoryException is thrown when the command history is empty or when {@code getPrevCommand}
+     * method has never been called yet.
      */
     public String getNextCommand() throws CommandHistoryException {
         if (isCommandHistoryEmpty()) {

--- a/src/main/java/seedu/programmer/ui/CommandHistory.java
+++ b/src/main/java/seedu/programmer/ui/CommandHistory.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.logging.Logger;
 
 import seedu.programmer.commons.core.LogsCenter;
+import seedu.programmer.ui.exceptions.CommandHistoryException;
 
 public class CommandHistory {
     static final String DEFAULT_COMMAND = "";
@@ -36,10 +37,10 @@ public class CommandHistory {
      * Returns the least recent command if the {@code counter} is already pointer at the oldest command.
      * @return The string of the next most recent entered command.
      */
-    public String getPrevCommand() {
+    public String getPrevCommand() throws CommandHistoryException {
         if (isCommandHistoryEmpty()) {
             logger.info("There is no command history.");
-            return DEFAULT_COMMAND;
+            throw new CommandHistoryException("No command has been executed, there is no history to navigate.");
         }
 
         if (!isCounterAtFirst()) {
@@ -57,14 +58,14 @@ public class CommandHistory {
      * Returns the most recent command if the {@code counter} is already pointer at the latest command.
      * @return The string of the next least recent entered command.
      */
-    public String getNextCommand() {
+    public String getNextCommand() throws CommandHistoryException {
         if (isCommandHistoryEmpty()) {
             logger.info("There is no command history.");
-            return DEFAULT_COMMAND;
+            throw new CommandHistoryException("No command has been executed, there is no history to navigate.");
         }
         if (isCounterAtDefault()) {
             logger.info("Previous command has not been executed before. Empty command returned.");
-            return DEFAULT_COMMAND;
+            throw new CommandHistoryException("There is no more recent command to navigate");
         }
         if (!isCounterAtLast()) {
             counter++;

--- a/src/main/java/seedu/programmer/ui/exceptions/CommandHistoryException.java
+++ b/src/main/java/seedu/programmer/ui/exceptions/CommandHistoryException.java
@@ -1,0 +1,9 @@
+package seedu.programmer.ui.exceptions;
+
+import seedu.programmer.logic.commands.exceptions.CommandException;
+
+public class CommandHistoryException extends Exception {
+    public CommandHistoryException(String msg) {
+        super(msg);
+    }
+}

--- a/src/main/java/seedu/programmer/ui/exceptions/CommandHistoryException.java
+++ b/src/main/java/seedu/programmer/ui/exceptions/CommandHistoryException.java
@@ -1,7 +1,5 @@
 package seedu.programmer.ui.exceptions;
 
-import seedu.programmer.logic.commands.exceptions.CommandException;
-
 public class CommandHistoryException extends Exception {
     public CommandHistoryException(String msg) {
         super(msg);

--- a/src/test/java/seedu/programmer/ui/CommandHistoryTest.java
+++ b/src/test/java/seedu/programmer/ui/CommandHistoryTest.java
@@ -2,9 +2,11 @@ package seedu.programmer.ui;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static seedu.programmer.ui.CommandHistory.DEFAULT_COMMAND;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
+
+import seedu.programmer.ui.exceptions.CommandHistoryException;
 
 public class CommandHistoryTest {
 
@@ -42,11 +44,11 @@ public class CommandHistoryTest {
     @Test
     public void getPrevCommand_emptyHistory_returnDefaultCommand() {
         CommandHistory commandHistory = new CommandHistory();
-        assertEquals(commandHistory.getPrevCommand(), DEFAULT_COMMAND);
+        assertThrows(CommandHistoryException.class, () -> commandHistory.getPrevCommand());
     }
 
     @Test
-    public void getPrevCommand_validHistory_success() {
+    public void getPrevCommand_validHistory_success() throws CommandHistoryException {
         CommandHistory commandHistory = new CommandHistory();
         commandHistory.add("one");
         commandHistory.add("two");
@@ -60,20 +62,20 @@ public class CommandHistoryTest {
     }
 
     @Test
-    public void getNextCommand_emptyHistory_returnDefaultCommand() {
+    public void getNextCommand_emptyHistory_returnDefaultCommand() throws CommandHistoryException {
         CommandHistory commandHistory = new CommandHistory();
-        assertEquals(commandHistory.getNextCommand(), DEFAULT_COMMAND);
+        assertThrows(CommandHistoryException.class, () -> commandHistory.getNextCommand());
     }
 
     @Test
-    public void getNextCommand_validHistory_success() {
+    public void getNextCommand_validHistory_success() throws CommandHistoryException {
         CommandHistory commandHistory = new CommandHistory();
         commandHistory.add("one");
         commandHistory.add("two");
         commandHistory.add("three");
 
         // getPrevCommand has not been executed --> expect the default empty command
-        assertEquals(commandHistory.getNextCommand(), "");
+        assertThrows(CommandHistoryException.class, () -> commandHistory.getNextCommand());
 
         // Execute getPrevCommand to the oldest command
         commandHistory.getPrevCommand();
@@ -87,7 +89,7 @@ public class CommandHistoryTest {
     }
 
     @Test
-    public void equals() {
+    public void equals() throws CommandHistoryException {
         CommandHistory commandHistoryOne = new CommandHistory();
         commandHistoryOne.add("test");
         CommandHistory commandHistoryOneCopy = new CommandHistory();


### PR DESCRIPTION
(instead of setting the textfield to be of an empty string)

fixes #311 
fixes #372 
fixes #317 

Implemented a new exception called `CommandHistoryException` that will be thrown when an unexpected or invalid keypress is detected.

For testing and review please.