### PR TITLE
Alternative CommandHistory implementation without using custom Exception

### DIFF
--- a/src/main/java/seedu/programmer/ui/CommandBox.java
+++ b/src/main/java/seedu/programmer/ui/CommandBox.java
@@ -1,11 +1,14 @@
 package seedu.programmer.ui;
 
+import java.util.logging.Logger;
+
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.TextField;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.Region;
+import seedu.programmer.commons.core.LogsCenter;
 import seedu.programmer.logic.commands.CommandResult;
 import seedu.programmer.logic.commands.exceptions.CommandException;
 import seedu.programmer.logic.parser.exceptions.ParseException;
@@ -16,6 +19,7 @@ import seedu.programmer.ui.exceptions.CommandHistoryException;
  */
 public class CommandBox extends UiPart<Region> {
 
+    private final Logger logger = LogsCenter.getLogger(getClass());
     public static final String ERROR_STYLE_CLASS = "error";
     private static final String FXML = "CommandBox.fxml";
 
@@ -60,21 +64,30 @@ public class CommandBox extends UiPart<Region> {
      */
     @FXML
     private void handleKeyPressed(KeyEvent event) {
+        boolean upPressed = event.getCode() == KeyCode.UP;
+        boolean downPressed = event.getCode() == KeyCode.DOWN;
+        boolean isNotUpOrDown = !upPressed && !downPressed;
+
+        // Neither up nor down pressed or no command history
+        if (isNotUpOrDown || commandHistory.isCommandHistoryEmpty()) {
+            return;
+        }
+
         try {
-            if (event.getCode() == KeyCode.UP) {
+            if (upPressed) {
                 commandTextField.setText(commandHistory.getPrevCommand());
-            } else if (event.getCode() == KeyCode.DOWN) {
-                commandTextField.setText(commandHistory.getNextCommand());
             } else {
-                return;
+                commandTextField.setText(commandHistory.getNextCommand());
             }
-            setStyleToDefault();
-            commandTextField.end();
-            event.consume(); // Consume Event
         } catch (CommandHistoryException e) {
+            logger.info("Unable to get previous or next command!");
             commandTextField.end();
             return;
         }
+
+        setStyleToDefault();
+        commandTextField.end();
+        event.consume(); // Consume Event
     }
 
     /**

--- a/src/main/java/seedu/programmer/ui/CommandBox.java
+++ b/src/main/java/seedu/programmer/ui/CommandBox.java
@@ -1,5 +1,6 @@
 package seedu.programmer.ui;
 
+import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.TextField;
 import javafx.scene.input.KeyCode;
@@ -8,6 +9,7 @@ import javafx.scene.layout.Region;
 import seedu.programmer.logic.commands.CommandResult;
 import seedu.programmer.logic.commands.exceptions.CommandException;
 import seedu.programmer.logic.parser.exceptions.ParseException;
+import seedu.programmer.ui.exceptions.CommandHistoryException;
 
 /**
  * The UI component that is responsible for receiving user command inputs.
@@ -48,7 +50,7 @@ public class CommandBox extends UiPart<Region> {
             commandExecutor.execute(commandText);
             commandTextField.setText("");
         } catch (CommandException | ParseException e) {
-            commandTextField.setText("");
+            setStyleToIndicateCommandFailure();
         }
     }
 
@@ -58,15 +60,22 @@ public class CommandBox extends UiPart<Region> {
      */
     @FXML
     private void handleKeyPressed(KeyEvent event) {
-        if (event.getCode() == KeyCode.UP) {
-            commandTextField.setText(commandHistory.getPrevCommand());
-        } else if (event.getCode() == KeyCode.DOWN) {
-            commandTextField.setText(commandHistory.getNextCommand());
-        } else {
-            return;
+        try {
+            if (event.getCode() == KeyCode.UP) {
+                commandTextField.setText(commandHistory.getPrevCommand());
+            }
+
+            if (event.getCode() == KeyCode.DOWN) {
+                commandTextField.setText(commandHistory.getNextCommand());
+            }
+
+//            event.consume(); // Consume Event
+        } catch (CommandHistoryException e) {
+            System.out.println("hi");
+        } finally {
+            commandTextField.end();
+
         }
-        commandTextField.end();
-        event.consume(); // Consume Event`
     }
 
     /**
@@ -74,6 +83,19 @@ public class CommandBox extends UiPart<Region> {
      */
     private void setStyleToDefault() {
         commandTextField.getStyleClass().remove(ERROR_STYLE_CLASS);
+    }
+
+    /**
+     * Sets the command box style to indicate a failed command.
+     */
+    private void setStyleToIndicateCommandFailure() {
+        ObservableList<String> styleClass = commandTextField.getStyleClass();
+
+        if (styleClass.contains(ERROR_STYLE_CLASS)) {
+            return;
+        }
+
+        styleClass.add(ERROR_STYLE_CLASS);
     }
 
     /**

--- a/src/main/java/seedu/programmer/ui/CommandBox.java
+++ b/src/main/java/seedu/programmer/ui/CommandBox.java
@@ -12,17 +12,16 @@ import seedu.programmer.commons.core.LogsCenter;
 import seedu.programmer.logic.commands.CommandResult;
 import seedu.programmer.logic.commands.exceptions.CommandException;
 import seedu.programmer.logic.parser.exceptions.ParseException;
-import seedu.programmer.ui.exceptions.CommandHistoryException;
 
 /**
  * The UI component that is responsible for receiving user command inputs.
  */
 public class CommandBox extends UiPart<Region> {
 
-    private final Logger logger = LogsCenter.getLogger(getClass());
     public static final String ERROR_STYLE_CLASS = "error";
     private static final String FXML = "CommandBox.fxml";
 
+    private final Logger logger = LogsCenter.getLogger(getClass());
     private final CommandExecutor commandExecutor;
     private final CommandHistory commandHistory = new CommandHistory();
 
@@ -77,6 +76,7 @@ public class CommandBox extends UiPart<Region> {
         }
 
         if (downAndAtLastCommand || upAndAtFirstCommand) {
+            logger.info("We are already at the oldest or newest command -> show current command");
             commandTextField.setText(commandHistory.getCurrentCommand());
         } else if (upPressed) {
             commandTextField.setText(commandHistory.getPrevCommand());

--- a/src/main/java/seedu/programmer/ui/CommandBox.java
+++ b/src/main/java/seedu/programmer/ui/CommandBox.java
@@ -63,18 +63,17 @@ public class CommandBox extends UiPart<Region> {
         try {
             if (event.getCode() == KeyCode.UP) {
                 commandTextField.setText(commandHistory.getPrevCommand());
-            }
-
-            if (event.getCode() == KeyCode.DOWN) {
+            } else if (event.getCode() == KeyCode.DOWN) {
                 commandTextField.setText(commandHistory.getNextCommand());
+            } else {
+                return;
             }
-
-//            event.consume(); // Consume Event
-        } catch (CommandHistoryException e) {
-            System.out.println("hi");
-        } finally {
+            setStyleToDefault();
             commandTextField.end();
-
+            event.consume(); // Consume Event
+        } catch (CommandHistoryException e) {
+            commandTextField.end();
+            return;
         }
     }
 

--- a/src/main/java/seedu/programmer/ui/CommandBox.java
+++ b/src/main/java/seedu/programmer/ui/CommandBox.java
@@ -1,6 +1,5 @@
 package seedu.programmer.ui;
 
-import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.TextField;
 import javafx.scene.input.KeyCode;
@@ -49,7 +48,7 @@ public class CommandBox extends UiPart<Region> {
             commandExecutor.execute(commandText);
             commandTextField.setText("");
         } catch (CommandException | ParseException e) {
-            setStyleToIndicateCommandFailure();
+            commandTextField.setText("");
         }
     }
 
@@ -75,19 +74,6 @@ public class CommandBox extends UiPart<Region> {
      */
     private void setStyleToDefault() {
         commandTextField.getStyleClass().remove(ERROR_STYLE_CLASS);
-    }
-
-    /**
-     * Sets the command box style to indicate a failed command.
-     */
-    private void setStyleToIndicateCommandFailure() {
-        ObservableList<String> styleClass = commandTextField.getStyleClass();
-
-        if (styleClass.contains(ERROR_STYLE_CLASS)) {
-            return;
-        }
-
-        styleClass.add(ERROR_STYLE_CLASS);
     }
 
     /**

--- a/src/main/java/seedu/programmer/ui/CommandBox.java
+++ b/src/main/java/seedu/programmer/ui/CommandBox.java
@@ -67,26 +67,24 @@ public class CommandBox extends UiPart<Region> {
         boolean upPressed = event.getCode() == KeyCode.UP;
         boolean downPressed = event.getCode() == KeyCode.DOWN;
         boolean isNotUpOrDown = !upPressed && !downPressed;
+        boolean noCommandHistoryPresent = commandHistory.isEmpty();
+        boolean downAndAtLastCommand = downPressed && commandHistory.isCounterAtLast();
+        boolean upAndAtFirstCommand = upPressed && commandHistory.isCounterAtFirst();
 
-        // Neither up nor down pressed or no command history
-        if (isNotUpOrDown || commandHistory.isCommandHistoryEmpty()) {
+        // Do nothing if neither up nor down pressed, or no command history
+        if (isNotUpOrDown || noCommandHistoryPresent) {
             return;
         }
 
-        try {
-            if (upPressed) {
-                commandTextField.setText(commandHistory.getPrevCommand());
-            } else {
-                commandTextField.setText(commandHistory.getNextCommand());
-            }
-        } catch (CommandHistoryException e) {
-            logger.info("Unable to get previous or next command!");
-            commandTextField.end();
-            return;
+        if (downAndAtLastCommand || upAndAtFirstCommand) {
+            commandTextField.setText(commandHistory.getCurrentCommand());
+        } else if (upPressed) {
+            commandTextField.setText(commandHistory.getPrevCommand());
+        } else {
+            commandTextField.setText(commandHistory.getNextCommand());
         }
 
-        setStyleToDefault();
-        commandTextField.end();
+        commandTextField.end(); // Move cursor to end of text field
         event.consume(); // Consume Event
     }
 

--- a/src/main/java/seedu/programmer/ui/CommandHistory.java
+++ b/src/main/java/seedu/programmer/ui/CommandHistory.java
@@ -8,8 +8,6 @@ import seedu.programmer.commons.core.LogsCenter;
 import seedu.programmer.ui.exceptions.CommandHistoryException;
 
 public class CommandHistory {
-    static final String DEFAULT_COMMAND = "";
-
     private final Logger logger = LogsCenter.getLogger(getClass());
     private List<String> commandHistory;
     private int counter;
@@ -24,7 +22,6 @@ public class CommandHistory {
 
     /**
      * Adds the {@code command} to the {@code commandHistory}.
-     * {@code counter} resets itself to point to the most recently added command to {@code commandHistory}.
      * @param command The string to be added to the history of commands.
      */
     public void add(String command) {
@@ -33,9 +30,9 @@ public class CommandHistory {
 
     /**
      * Returns the next most recently entered command according to the {@code counter} pointer.
-     * Returns the {@code DEFAULT_COMMAND} if the {@code commandHistory} is empty.
      * Returns the least recent command if the {@code counter} is already pointer at the oldest command.
      * @return The string of the next most recent entered command.
+     * @throws CommandHistoryException is thrown when the command history is empty.
      */
     public String getPrevCommand() throws CommandHistoryException {
         if (isCommandHistoryEmpty()) {
@@ -54,9 +51,10 @@ public class CommandHistory {
 
     /**
      * Returns the next least recent entered command according to the {@code counter} pointer.
-     * Returns the {@code DEFAULT_COMMAND} if the {@code commandHistory} is empty.
      * Returns the most recent command if the {@code counter} is already pointer at the latest command.
      * @return The string of the next least recent entered command.
+     * @throws CommandHistoryException is thrown when the command history is empty or when {@code getPrevCommand}
+     * method has never been called yet.
      */
     public String getNextCommand() throws CommandHistoryException {
         if (isCommandHistoryEmpty()) {

--- a/src/main/java/seedu/programmer/ui/CommandHistory.java
+++ b/src/main/java/seedu/programmer/ui/CommandHistory.java
@@ -5,19 +5,17 @@ import java.util.List;
 import java.util.logging.Logger;
 
 import seedu.programmer.commons.core.LogsCenter;
-import seedu.programmer.ui.exceptions.CommandHistoryException;
 
 public class CommandHistory {
     private final Logger logger = LogsCenter.getLogger(getClass());
     private List<String> commandHistory;
-    private int counter;
+    private int currCommandIndex;
 
     /**
      * Constructor to initialize a new {@code CommandHistory} object.
      */
     public CommandHistory() {
         commandHistory = new ArrayList<>();
-        counter = 0;
     }
 
     /**
@@ -25,21 +23,20 @@ public class CommandHistory {
      * @param command The string to be added to the history of commands.
      */
     public void add(String command) {
-        addCommandToHistory(command);
+        commandHistory.add(command);
+        currCommandIndex = commandHistory.size() - 1;
     }
 
     /**
      * Returns the next most recently entered command according to the {@code counter} pointer.
      * Returns the least recent command if the {@code counter} is already pointer at the oldest command.
      * @return The string of the next most recent entered command.
-     * @throws CommandHistoryException is thrown when the command history is empty.
      */
-    public String getPrevCommand() throws CommandHistoryException {
-        if (!isCounterAtFirst()) {
-            counter--;
-        }
-
-        String result = commandHistory.get(counter);
+    public String getPrevCommand() {
+        // We should not call getPrevCommand() if the counter is already at the oldest command.
+        assert !isCounterAtFirst();
+        currCommandIndex--;
+        String result = commandHistory.get(currCommandIndex);
         logger.info("Previous Command retrieved: " + result);
         return result;
     }
@@ -48,16 +45,12 @@ public class CommandHistory {
      * Returns the next least recent entered command according to the {@code counter} pointer.
      * Returns the most recent command if the {@code counter} is already pointer at the latest command.
      * @return The string of the next least recent entered command.
-     * @throws CommandHistoryException is thrown when the command history is empty or when {@code getPrevCommand}
-     * method has never been called yet.
      */
-    public String getNextCommand() throws CommandHistoryException {
-        if (!isCounterAtLast()) {
-            counter++;
-        }
-
-        String result = commandHistory.get(counter);
-
+    public String getNextCommand() {
+        // We should not call getNextCommand() if the counter is already at the latest command.
+        assert !isCounterAtLast();
+        currCommandIndex++;
+        String result = commandHistory.get(currCommandIndex);
         logger.info("Next Command retrieved: " + result);
         return result;
     }
@@ -77,30 +70,22 @@ public class CommandHistory {
         // state check
         CommandHistory e = (CommandHistory) other;
         return commandHistory.equals(e.commandHistory)
-                && counter == e.counter;
+                && currCommandIndex == e.currCommandIndex;
     }
 
-    public boolean isCounterAtDefault() {
-        return counter == commandHistory.size();
-    }
-    public boolean isCommandHistoryEmpty() {
+    public boolean isEmpty() {
         return commandHistory.size() == 0;
     }
 
-    private void resetCounterToDefault() {
-        counter = commandHistory.size();
-    }
-
-    private void addCommandToHistory(String command) {
-        commandHistory.add(command);
-        resetCounterToDefault();
-    }
-
     public boolean isCounterAtLast() {
-        return counter == commandHistory.size() - 1;
+        return currCommandIndex == commandHistory.size() - 1;
     }
 
     public boolean isCounterAtFirst() {
-        return counter == 0;
+        return currCommandIndex == 0;
+    }
+
+    public String getCurrentCommand() {
+        return commandHistory.get(currCommandIndex);
     }
 }

--- a/src/main/java/seedu/programmer/ui/CommandHistory.java
+++ b/src/main/java/seedu/programmer/ui/CommandHistory.java
@@ -86,6 +86,6 @@ public class CommandHistory {
     }
 
     public String getCurrentCommand() {
-        return commandHistory.get(currCommandIndex);
+        return isEmpty() ? "" : commandHistory.get(currCommandIndex);
     }
 }

--- a/src/main/java/seedu/programmer/ui/CommandHistory.java
+++ b/src/main/java/seedu/programmer/ui/CommandHistory.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.logging.Logger;
 
 import seedu.programmer.commons.core.LogsCenter;
+import seedu.programmer.ui.exceptions.CommandHistoryException;
 
 public class CommandHistory {
     static final String DEFAULT_COMMAND = "";
@@ -36,10 +37,10 @@ public class CommandHistory {
      * Returns the least recent command if the {@code counter} is already pointer at the oldest command.
      * @return The string of the next most recent entered command.
      */
-    public String getPrevCommand() {
+    public String getPrevCommand() throws CommandHistoryException {
         if (isCommandHistoryEmpty()) {
             logger.info("There is no command history.");
-            return DEFAULT_COMMAND;
+            throw new CommandHistoryException("No command has been executed, there is no history to navigate.");
         }
 
         if (!isCounterAtFirst()) {
@@ -57,14 +58,14 @@ public class CommandHistory {
      * Returns the most recent command if the {@code counter} is already pointer at the latest command.
      * @return The string of the next least recent entered command.
      */
-    public String getNextCommand() {
+    public String getNextCommand() throws CommandHistoryException {
         if (isCommandHistoryEmpty()) {
             logger.info("There is no command history.");
-            return DEFAULT_COMMAND;
+            throw new CommandHistoryException("No command has been executed, there is no history to navigate.");
         }
         if (isCounterAtDefault()) {
             logger.info("Previous command has not been executed before. Empty command returned.");
-            return DEFAULT_COMMAND;
+            throw new CommandHistoryException("There is no more recent command to navigate");
         }
         if (!isCounterAtLast()) {
             counter++;

--- a/src/main/java/seedu/programmer/ui/CommandHistory.java
+++ b/src/main/java/seedu/programmer/ui/CommandHistory.java
@@ -17,7 +17,7 @@ public class CommandHistory {
      */
     public CommandHistory() {
         commandHistory = new ArrayList<>();
-        counter = commandHistory.size();
+        counter = 0;
     }
 
     /**
@@ -35,16 +35,11 @@ public class CommandHistory {
      * @throws CommandHistoryException is thrown when the command history is empty.
      */
     public String getPrevCommand() throws CommandHistoryException {
-        if (isCommandHistoryEmpty()) {
-            logger.info("There is no command history.");
-            throw new CommandHistoryException("No command has been executed, there is no history to navigate.");
-        }
-
         if (!isCounterAtFirst()) {
             counter--;
         }
-        String result = commandHistory.get(counter);
 
+        String result = commandHistory.get(counter);
         logger.info("Previous Command retrieved: " + result);
         return result;
     }
@@ -57,17 +52,10 @@ public class CommandHistory {
      * method has never been called yet.
      */
     public String getNextCommand() throws CommandHistoryException {
-        if (isCommandHistoryEmpty()) {
-            logger.info("There is no command history.");
-            throw new CommandHistoryException("No command has been executed, there is no history to navigate.");
-        }
-        if (isCounterAtDefault()) {
-            logger.info("Previous command has not been executed before. Empty command returned.");
-            throw new CommandHistoryException("There is no more recent command to navigate");
-        }
         if (!isCounterAtLast()) {
             counter++;
         }
+
         String result = commandHistory.get(counter);
 
         logger.info("Next Command retrieved: " + result);
@@ -92,10 +80,10 @@ public class CommandHistory {
                 && counter == e.counter;
     }
 
-    private boolean isCounterAtDefault() {
+    public boolean isCounterAtDefault() {
         return counter == commandHistory.size();
     }
-    private boolean isCommandHistoryEmpty() {
+    public boolean isCommandHistoryEmpty() {
         return commandHistory.size() == 0;
     }
 
@@ -108,11 +96,11 @@ public class CommandHistory {
         resetCounterToDefault();
     }
 
-    private boolean isCounterAtLast() {
+    public boolean isCounterAtLast() {
         return counter == commandHistory.size() - 1;
     }
 
-    private boolean isCounterAtFirst() {
+    public boolean isCounterAtFirst() {
         return counter == 0;
     }
 }

--- a/src/main/java/seedu/programmer/ui/exceptions/CommandHistoryException.java
+++ b/src/main/java/seedu/programmer/ui/exceptions/CommandHistoryException.java
@@ -1,0 +1,9 @@
+package seedu.programmer.ui.exceptions;
+
+import seedu.programmer.logic.commands.exceptions.CommandException;
+
+public class CommandHistoryException extends Exception {
+    public CommandHistoryException(String msg) {
+        super(msg);
+    }
+}

--- a/src/main/java/seedu/programmer/ui/exceptions/CommandHistoryException.java
+++ b/src/main/java/seedu/programmer/ui/exceptions/CommandHistoryException.java
@@ -1,7 +1,5 @@
 package seedu.programmer.ui.exceptions;
 
-import seedu.programmer.logic.commands.exceptions.CommandException;
-
 public class CommandHistoryException extends Exception {
     public CommandHistoryException(String msg) {
         super(msg);

--- a/src/main/java/seedu/programmer/ui/exceptions/CommandHistoryException.java
+++ b/src/main/java/seedu/programmer/ui/exceptions/CommandHistoryException.java
@@ -1,7 +1,0 @@
-package seedu.programmer.ui.exceptions;
-
-public class CommandHistoryException extends Exception {
-    public CommandHistoryException(String msg) {
-        super(msg);
-    }
-}

--- a/src/test/java/seedu/programmer/ui/CommandHistoryTest.java
+++ b/src/test/java/seedu/programmer/ui/CommandHistoryTest.java
@@ -2,85 +2,75 @@ package seedu.programmer.ui;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import seedu.programmer.ui.exceptions.CommandHistoryException;
 
 public class CommandHistoryTest {
 
+    private CommandHistory commandHistory;
+
+    @BeforeEach
+    public void setUp() {
+        commandHistory = new CommandHistory();
+    }
+
     @Test
     public void add_sameInputs_equal() {
-        CommandHistory commandHistoryOne = new CommandHistory();
-        commandHistoryOne.add("test input one");
-        commandHistoryOne.add("test input two");
+        commandHistory.add("test input one");
+        commandHistory.add("test input two");
 
         CommandHistory commandHistoryTwo = new CommandHistory();
         commandHistoryTwo.add("test input one");
 
-        assertNotEquals(commandHistoryOne, commandHistoryTwo);
+        assertNotEquals(commandHistory, commandHistoryTwo);
 
         commandHistoryTwo.add("test input two");
-        assertEquals(commandHistoryOne, commandHistoryTwo);
+        assertEquals(commandHistory, commandHistoryTwo);
 
         commandHistoryTwo.add("test input three");
-        assertNotEquals(commandHistoryOne, commandHistoryTwo);
+        assertNotEquals(commandHistory, commandHistoryTwo);
     }
 
     @Test
     public void add_differentInputs_notEqual() {
-        CommandHistory commandHistoryOne = new CommandHistory();
-        commandHistoryOne.add("test input one");
-        commandHistoryOne.add("test input two");
+        commandHistory.add("test input one");
+        commandHistory.add("test input two");
 
         CommandHistory commandHistoryTwo = new CommandHistory();
         commandHistoryTwo.add("test input two");
         commandHistoryTwo.add("test input one");
 
-        assertNotEquals(commandHistoryOne, commandHistoryTwo);
-    }
-
-    @Test
-    public void getPrevCommand_emptyHistory_returnDefaultCommand() {
-        CommandHistory commandHistory = new CommandHistory();
-        assertThrows(CommandHistoryException.class, () -> commandHistory.getPrevCommand());
+        assertNotEquals(commandHistory, commandHistoryTwo);
     }
 
     @Test
     public void getPrevCommand_validHistory_success() throws CommandHistoryException {
-        CommandHistory commandHistory = new CommandHistory();
         commandHistory.add("one");
         commandHistory.add("two");
 
-        // Retrieve latest command
-        assertEquals(commandHistory.getPrevCommand(), "two");
-        // Retrieve next latest command
+        // Retrieve previous command
         assertEquals(commandHistory.getPrevCommand(), "one");
-        // Oldest command is returned when there is no older history
-        assertEquals(commandHistory.getPrevCommand(), "one");
-    }
 
-    @Test
-    public void getNextCommand_emptyHistory_returnDefaultCommand() throws CommandHistoryException {
-        CommandHistory commandHistory = new CommandHistory();
-        assertThrows(CommandHistoryException.class, () -> commandHistory.getNextCommand());
+        // Retrieve the next previous command -> return the current command
+        assertEquals(commandHistory.getCurrentCommand(), "one");
     }
 
     @Test
     public void getNextCommand_validHistory_success() throws CommandHistoryException {
-        CommandHistory commandHistory = new CommandHistory();
         commandHistory.add("one");
         commandHistory.add("two");
         commandHistory.add("three");
 
-        // getPrevCommand has not been executed --> expect the default empty command
-        assertThrows(CommandHistoryException.class, () -> commandHistory.getNextCommand());
+        // Pressing down key will return the current command if it is the most recent command
+        assertEquals(commandHistory.getCurrentCommand(), "three");
 
-        // Execute getPrevCommand to the oldest command
+        // Pressing up key thrice will return the first command
         commandHistory.getPrevCommand();
         commandHistory.getPrevCommand();
-        commandHistory.getPrevCommand();
+        assertEquals(commandHistory.getCurrentCommand(), "one");
 
         // Retrieve the next command
         assertEquals(commandHistory.getNextCommand(), "two");
@@ -89,7 +79,20 @@ public class CommandHistoryTest {
     }
 
     @Test
-    public void equals() throws CommandHistoryException {
+    public void getCurrentCommand_emptyHistory_returnsEmptyString() {
+        assertEquals(commandHistory.getCurrentCommand(), "");
+    }
+
+    @Test
+    public void getCurrentCommand_validHistory_returnsMostRecentCommand() {
+        commandHistory.add("first command");
+        commandHistory.add("second command");
+        commandHistory.add("third command");
+        assertEquals(commandHistory.getCurrentCommand(), "third command");
+    }
+
+    @Test
+    public void equals() {
         CommandHistory commandHistoryOne = new CommandHistory();
         commandHistoryOne.add("test");
         CommandHistory commandHistoryOneCopy = new CommandHistory();

--- a/src/test/java/seedu/programmer/ui/CommandHistoryTest.java
+++ b/src/test/java/seedu/programmer/ui/CommandHistoryTest.java
@@ -2,9 +2,11 @@ package seedu.programmer.ui;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static seedu.programmer.ui.CommandHistory.DEFAULT_COMMAND;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
+
+import seedu.programmer.ui.exceptions.CommandHistoryException;
 
 public class CommandHistoryTest {
 
@@ -42,11 +44,11 @@ public class CommandHistoryTest {
     @Test
     public void getPrevCommand_emptyHistory_returnDefaultCommand() {
         CommandHistory commandHistory = new CommandHistory();
-        assertEquals(commandHistory.getPrevCommand(), DEFAULT_COMMAND);
+        assertThrows(CommandHistoryException.class, () -> commandHistory.getPrevCommand());
     }
 
     @Test
-    public void getPrevCommand_validHistory_success() {
+    public void getPrevCommand_validHistory_success() throws CommandHistoryException {
         CommandHistory commandHistory = new CommandHistory();
         commandHistory.add("one");
         commandHistory.add("two");
@@ -60,20 +62,20 @@ public class CommandHistoryTest {
     }
 
     @Test
-    public void getNextCommand_emptyHistory_returnDefaultCommand() {
+    public void getNextCommand_emptyHistory_returnDefaultCommand() throws CommandHistoryException {
         CommandHistory commandHistory = new CommandHistory();
-        assertEquals(commandHistory.getNextCommand(), DEFAULT_COMMAND);
+        assertThrows(CommandHistoryException.class, () -> commandHistory.getNextCommand());
     }
 
     @Test
-    public void getNextCommand_validHistory_success() {
+    public void getNextCommand_validHistory_success() throws CommandHistoryException {
         CommandHistory commandHistory = new CommandHistory();
         commandHistory.add("one");
         commandHistory.add("two");
         commandHistory.add("three");
 
         // getPrevCommand has not been executed --> expect the default empty command
-        assertEquals(commandHistory.getNextCommand(), "");
+        assertThrows(CommandHistoryException.class, () -> commandHistory.getNextCommand());
 
         // Execute getPrevCommand to the oldest command
         commandHistory.getPrevCommand();
@@ -87,7 +89,7 @@ public class CommandHistoryTest {
     }
 
     @Test
-    public void equals() {
+    public void equals() throws CommandHistoryException {
         CommandHistory commandHistoryOne = new CommandHistory();
         commandHistoryOne.add("test");
         CommandHistory commandHistoryOneCopy = new CommandHistory();

--- a/src/test/java/seedu/programmer/ui/CommandHistoryTest.java
+++ b/src/test/java/seedu/programmer/ui/CommandHistoryTest.java
@@ -6,8 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import seedu.programmer.ui.exceptions.CommandHistoryException;
-
 public class CommandHistoryTest {
 
     private CommandHistory commandHistory;
@@ -47,7 +45,7 @@ public class CommandHistoryTest {
     }
 
     @Test
-    public void getPrevCommand_validHistory_success() throws CommandHistoryException {
+    public void getPrevCommand_validHistory_success() {
         commandHistory.add("one");
         commandHistory.add("two");
 
@@ -59,7 +57,7 @@ public class CommandHistoryTest {
     }
 
     @Test
-    public void getNextCommand_validHistory_success() throws CommandHistoryException {
+    public void getNextCommand_validHistory_success() {
         commandHistory.add("one");
         commandHistory.add("two");
         commandHistory.add("three");


### PR DESCRIPTION
Proposed implementation for: #375 

- use conditionals to check different cases when user presses the up or down key
- create `getCurrentCommand()` method for cases where we want to return the same command that was just shown to user
- use getNextCommand and getPreviousCommand only when we really want to get the next or previous command
- remove use of default command and related methods
- CommandHistory `add()` method will add directly to the list of commands
- rename `counter` to `currCommandIndex` (i.e. the index of the current command in the list)

Considerations:
- might be harder to simulate user input but easier to test individual methods
- might need to create a separate test file for CommandBox where we actually simulate the pressing of the down and up arrow keys