### PR TITLE
Fix bug when there are no proper error message feedback

### DIFF
--- a/src/main/java/seedu/programmer/commons/core/Messages.java
+++ b/src/main/java/seedu/programmer/commons/core/Messages.java
@@ -12,5 +12,6 @@ public class Messages {
     public static final String MESSAGE_UNKNOWN_ARGUMENT_FLAG = "Unknown flag(s) detected for this command: %1$s \n%2$s";
     public static final String MESSAGE_EMPTY_ARGUMENT = "Empty argument(s) provided for this command!\n%1$s";
     public static final String MESSAGE_MISSING_ARGUMENT = "Missing argument(s) provided for this command!\n%1$s";
+    public static final String MESSAGE_TEMPLATE = "%1$s\n%2$s";
 
 }

--- a/src/main/java/seedu/programmer/logic/commands/AddLabCommand.java
+++ b/src/main/java/seedu/programmer/logic/commands/AddLabCommand.java
@@ -20,7 +20,7 @@ public class AddLabCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a lab to all the students in the list.\n"
             + "Parameters: "
-            + PREFIX_LAB_NUM + "<LAB_NUMBER>"
+            + PREFIX_LAB_NUM + "<LAB_NUMBER> "
             + PREFIX_LAB_TOTAL + "<TOTAL_SCORE>\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_LAB_NUM + "1 "

--- a/src/main/java/seedu/programmer/logic/commands/EditLabCommand.java
+++ b/src/main/java/seedu/programmer/logic/commands/EditLabCommand.java
@@ -31,12 +31,14 @@ public class EditLabCommand extends Command {
             + PREFIX_LAB_TOTAL + "15";
 
     public static final String MESSAGE_EDIT_LAB_SUCCESS = "Updated %1$s!";
-
     public static final String MESSAGE_SCORE_SHOULD_BE_POSITIVE = "The lab total score %f should be a positive value.";
-
     public static final String MESSAGE_LAB_ALREADY_EXISTS = "Lab %d already exists.";
-
     public static final String MESSAGE_LAB_NOT_EXISTS = "Lab %d doesn't exist.";
+    public static final String MESSAGE_ARGUMENT_SHOULD_BE_SPECIFIED =
+            "Kindly specify if you want to edit the lab number and/or the total score.\n%1$s";
+    public static final String MESSAGE_MISSING_LAB_TO_BE_EDITED =
+            "Kindly specify the lab number that you would like to edit using the " + PREFIX_LAB_NUM + "flag.\n%1$s";
+    public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! ";
 
     private final int newLabNum;
     private final Integer total;

--- a/src/main/java/seedu/programmer/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/programmer/logic/parser/EditCommandParser.java
@@ -1,7 +1,7 @@
 package seedu.programmer.logic.parser;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.programmer.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.programmer.commons.core.Messages.MESSAGE_TEMPLATE;
 import static seedu.programmer.commons.core.Messages.MESSAGE_UNKNOWN_ARGUMENT_FLAG;
 import static seedu.programmer.logic.parser.CliSyntax.PREFIX_CLASS_ID;
 import static seedu.programmer.logic.parser.CliSyntax.PREFIX_EMAIL;
@@ -31,6 +31,7 @@ public class EditCommandParser implements Parser<EditCommand> {
         requireNonNull(args);
         ArgumentMultimap argMultimap;
         Index index;
+        EditStudentDescriptor editstudentDescriptor;
 
         try {
             argMultimap =
@@ -42,34 +43,40 @@ public class EditCommandParser implements Parser<EditCommand> {
         }
 
         try {
+            // ParseException will be thrown from the parseIndex method if index from Preamble cannot be parsed
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
+            editstudentDescriptor = new EditStudentDescriptor();
+
+            if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
+                editstudentDescriptor.setName(ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get()));
+            }
+            if (argMultimap.getValue(PREFIX_STUDENT_ID).isPresent()) {
+                editstudentDescriptor.setStudentId(ParserUtil.parseStudentId(argMultimap
+                        .getValue(PREFIX_STUDENT_ID).get()));
+            }
+            if (argMultimap.getValue(PREFIX_CLASS_ID).isPresent()) {
+                editstudentDescriptor.setClassId(ParserUtil.parseClassId(argMultimap.getValue(PREFIX_CLASS_ID).get()));
+            }
+            if (argMultimap.getValue(PREFIX_EMAIL).isPresent()) {
+                editstudentDescriptor.setEmail(ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get()));
+            }
+            if (argMultimap.getValue(PREFIX_LAB_NUM).isPresent()
+                    && argMultimap.getValue(PREFIX_LAB_RESULT).isPresent()) {
+                int labNum = ParserUtil.parseLabNum(argMultimap.getValue(PREFIX_LAB_NUM).orElse(null));
+                Integer result = ParserUtil.parseResult(argMultimap.getValue(PREFIX_LAB_RESULT).orElse(null));
+                Lab labResult = new Lab(labNum);
+                editstudentDescriptor.setLab(labResult, result);
+            } else if (argMultimap.getValue(PREFIX_LAB_NUM).isPresent()
+                    || argMultimap.getValue(PREFIX_LAB_RESULT).isPresent()) {
+                //if only one of the required two arguments provided, we will throw an exception
+                throw new ParseException(Lab.MESSAGE_LAB_SCORE_AND_LAB_NUMBER_REQUIREMENT);
+            }
+
+            if (!editstudentDescriptor.isAnyFieldEdited()) {
+                throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);
+            }
         } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE), pe);
-        }
-
-        EditStudentDescriptor editstudentDescriptor = new EditStudentDescriptor();
-        if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
-            editstudentDescriptor.setName(ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get()));
-        }
-        if (argMultimap.getValue(PREFIX_STUDENT_ID).isPresent()) {
-            editstudentDescriptor.setStudentId(ParserUtil.parseStudentId(argMultimap
-                    .getValue(PREFIX_STUDENT_ID).get()));
-        }
-        if (argMultimap.getValue(PREFIX_CLASS_ID).isPresent()) {
-            editstudentDescriptor.setClassId(ParserUtil.parseClassId(argMultimap.getValue(PREFIX_CLASS_ID).get()));
-        }
-        if (argMultimap.getValue(PREFIX_EMAIL).isPresent()) {
-            editstudentDescriptor.setEmail(ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get()));
-        }
-        if (argMultimap.getValue(PREFIX_LAB_NUM).isPresent() && argMultimap.getValue(PREFIX_LAB_RESULT).isPresent()) {
-            int labNum = ParserUtil.parseLabNum(argMultimap.getValue(PREFIX_LAB_NUM).orElse(null));
-            Integer result = ParserUtil.parseTotal(argMultimap.getValue(PREFIX_LAB_RESULT).orElse(null));
-            Lab labResult = new Lab(labNum);
-            editstudentDescriptor.setLab(labResult, result);
-        }
-
-        if (!editstudentDescriptor.isAnyFieldEdited()) {
-            throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);
+            throw new ParseException(String.format(MESSAGE_TEMPLATE, pe.getMessage(), EditCommand.MESSAGE_USAGE));
         }
 
         return new EditCommand(index, editstudentDescriptor);

--- a/src/main/java/seedu/programmer/logic/parser/EditLabCommandParser.java
+++ b/src/main/java/seedu/programmer/logic/parser/EditLabCommandParser.java
@@ -1,8 +1,11 @@
 package seedu.programmer.logic.parser;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.programmer.commons.core.Messages.MESSAGE_MISSING_ARGUMENT;
+import static seedu.programmer.commons.core.Messages.MESSAGE_TEMPLATE;
 import static seedu.programmer.commons.core.Messages.MESSAGE_UNKNOWN_ARGUMENT_FLAG;
+import static seedu.programmer.logic.commands.EditLabCommand.MESSAGE_ARGUMENT_SHOULD_BE_SPECIFIED;
+import static seedu.programmer.logic.commands.EditLabCommand.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.programmer.logic.commands.EditLabCommand.MESSAGE_MISSING_LAB_TO_BE_EDITED;
 import static seedu.programmer.logic.parser.CliSyntax.PREFIX_LAB_NEW_LAB_NUM;
 import static seedu.programmer.logic.parser.CliSyntax.PREFIX_LAB_NUM;
 import static seedu.programmer.logic.parser.CliSyntax.PREFIX_LAB_TOTAL;
@@ -38,34 +41,41 @@ public class EditLabCommandParser implements Parser<EditLabCommand> {
                     String.format(MESSAGE_UNKNOWN_ARGUMENT_FLAG, e.getMessage(), EditLabCommand.MESSAGE_USAGE));
         }
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_LAB_NUM)
-                || !argMultimap.getPreamble().isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_MISSING_ARGUMENT, EditLabCommand.MESSAGE_USAGE));
+        try {
+            if (!argMultimap.getPreamble().isEmpty()) {
+                throw new ParseException(MESSAGE_INVALID_COMMAND_FORMAT);
+            }
+
+            if (!arePrefixesPresent(argMultimap, PREFIX_LAB_NUM)) {
+                throw new ParseException(MESSAGE_MISSING_LAB_TO_BE_EDITED);
+            }
+
+            if (argMultimap.getValue(PREFIX_LAB_NEW_LAB_NUM).isPresent()
+                    && argMultimap.getValue(PREFIX_LAB_TOTAL).isPresent()) {
+                // Provided new lab number and total score
+                int labNum = ParserUtil.parseLabNum(argMultimap.getValue(PREFIX_LAB_NUM).orElse(null));
+                int newLabNum = ParserUtil.parseLabNum(argMultimap.getValue(PREFIX_LAB_NEW_LAB_NUM).orElse(null));
+                int total = ParserUtil.parseTotal(argMultimap.getValue(PREFIX_LAB_TOTAL).orElse(null));
+                Lab labResult = new Lab(labNum);
+                return new EditLabCommand(labResult, newLabNum, total);
+            } else if (argMultimap.getValue(PREFIX_LAB_NEW_LAB_NUM).isPresent()) {
+                // Provided new lab number only
+                int labNum = ParserUtil.parseLabNum(argMultimap.getValue(PREFIX_LAB_NUM).orElse(null));
+                int newLabNum = ParserUtil.parseLabNum(argMultimap.getValue(PREFIX_LAB_NEW_LAB_NUM).orElse(null));
+                Lab labResult = new Lab(labNum);
+                return new EditLabCommand(labResult, newLabNum);
+            } else if (argMultimap.getValue(PREFIX_LAB_TOTAL).isPresent()) {
+                int labNum = ParserUtil.parseLabNum(argMultimap.getValue(PREFIX_LAB_NUM).orElse(null));
+                int total = ParserUtil.parseTotal(argMultimap.getValue(PREFIX_LAB_TOTAL).orElse(null));
+                Lab labResult = new Lab(labNum);
+                return new EditLabCommand(labResult, total);
+            } else {
+                throw new ParseException(MESSAGE_ARGUMENT_SHOULD_BE_SPECIFIED);
+            }
+        } catch (ParseException pe) {
+            throw new ParseException(String.format(MESSAGE_TEMPLATE, pe.getMessage(), EditLabCommand.MESSAGE_USAGE));
         }
 
-        if (argMultimap.getValue(PREFIX_LAB_NEW_LAB_NUM).isPresent()
-                && argMultimap.getValue(PREFIX_LAB_TOTAL).isPresent()) {
-            // Provided new lab number and total score
-            int labNum = ParserUtil.parseLabNum(argMultimap.getValue(PREFIX_LAB_NUM).orElse(null));
-            int newLabNum = ParserUtil.parseLabNum(argMultimap.getValue(PREFIX_LAB_NEW_LAB_NUM).orElse(null));
-            Integer total = ParserUtil.parseResult(argMultimap.getValue(PREFIX_LAB_TOTAL).orElse(null));
-            Lab labResult = new Lab(labNum);
-            return new EditLabCommand(labResult, newLabNum, total);
-        } else if (argMultimap.getValue(PREFIX_LAB_NEW_LAB_NUM).isPresent()) {
-            // Provided new lab number only
-            int labNum = ParserUtil.parseLabNum(argMultimap.getValue(PREFIX_LAB_NUM).orElse(null));
-            int newLabNum = ParserUtil.parseLabNum(argMultimap.getValue(PREFIX_LAB_NEW_LAB_NUM).orElse(null));
-            // TODO: find out the labNum's total score
-            // Lab labResult = new Lab(labNum, totalScore)
-            Lab labResult = new Lab(labNum);
-            return new EditLabCommand(labResult, newLabNum);
-        } else {
-            assert(argMultimap.getValue(PREFIX_LAB_TOTAL).isPresent());
-            int labNum = ParserUtil.parseLabNum(argMultimap.getValue(PREFIX_LAB_NUM).orElse(null));
-            Integer total = ParserUtil.parseResult(argMultimap.getValue(PREFIX_LAB_TOTAL).orElse(null));
-            Lab labResult = new Lab(labNum);
-            return new EditLabCommand(labResult, total);
-        }
     }
 
     /**

--- a/src/main/java/seedu/programmer/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/programmer/logic/parser/ParserUtil.java
@@ -1,14 +1,13 @@
 package seedu.programmer.logic.parser;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.programmer.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import seedu.programmer.commons.core.index.Index;
 import seedu.programmer.commons.util.StringUtil;
-import seedu.programmer.logic.commands.EditLabCommand;
 import seedu.programmer.logic.parser.exceptions.ParseException;
 import seedu.programmer.model.student.ClassId;
 import seedu.programmer.model.student.Email;
+import seedu.programmer.model.student.Lab;
 import seedu.programmer.model.student.Name;
 import seedu.programmer.model.student.StudentId;
 
@@ -17,7 +16,8 @@ import seedu.programmer.model.student.StudentId;
  */
 public class ParserUtil {
 
-    public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
+    public static final String MESSAGE_INVALID_INDEX = "Index is not a positive integer.";
+    public static final String MESSAGE_EMPTY_INDEX = "Please provide a positive integer as index.";
 
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it.
@@ -27,6 +27,9 @@ public class ParserUtil {
      */
     public static Index parseIndex(String oneBasedIndex) throws ParseException {
         String trimmedIndex = oneBasedIndex.trim();
+        if (trimmedIndex.isEmpty()) {
+            throw new ParseException(MESSAGE_EMPTY_INDEX);
+        }
         if (!StringUtil.isNonZeroUnsignedInteger(trimmedIndex)) {
             throw new ParseException(MESSAGE_INVALID_INDEX);
         }
@@ -97,33 +100,20 @@ public class ParserUtil {
         return new Email(formattedEmail);
     }
 
-    //todo: for test of show feature only
-
-    /**
-     * Parses the index of the student that the lab result is added to.
-     *
-     * @param index the index of the student.
-     * */
-    public static int parseNumber(String index) {
-        if (index == null) {
-            return 1;
-        }
-        return Integer.parseInt(index.trim());
-    }
-
     /**
      * Parses the title of the lab assignment.
+     *
      *  @param labNum the lab number
      * */
     public static int parseLabNum(String labNum) throws ParseException {
         try {
             int value = Integer.parseInt(labNum);
             if (value < 0) {
-                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditLabCommand.MESSAGE_USAGE));
+                throw new ParseException(Lab.MESSAGE_LAB_NUMBER_CONSTRAINT);
             }
             return value;
         } catch (NumberFormatException e) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditLabCommand.MESSAGE_USAGE));
+            throw new ParseException(Lab.MESSAGE_LAB_NUMBER_CONSTRAINT);
         }
     }
 
@@ -133,11 +123,15 @@ public class ParserUtil {
      * @param result the result of the lab assignment.
      * */
     public static Integer parseResult (String result) throws ParseException {
-        Integer res = Integer.parseInt(result.trim());
+        String trimmedResult = result.trim();
+        if (trimmedResult.isEmpty()) {
+            throw new ParseException(Lab.MESSAGE_LAB_SCORE_CONSTRAINT);
+        }
+        Integer res = Integer.parseInt(trimmedResult);
         if (result == null) {
             return 0;
         } else if (res < 0) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditLabCommand.MESSAGE_USAGE));
+            throw new ParseException(Lab.MESSAGE_LAB_SCORE_CONSTRAINT);
         }
         return Integer.parseInt(result.trim());
     }
@@ -148,11 +142,15 @@ public class ParserUtil {
      * @param total the total score of the lab assignment.
      * */
     public static Integer parseTotal(String total) throws ParseException {
-        Integer res = Integer.parseInt(total.trim());
+        String trimmedResult = total.trim();
+        if (trimmedResult.isEmpty()) {
+            throw new ParseException(Lab.MESSAGE_LAB_SCORE_CONSTRAINT);
+        }
+        Integer res = Integer.parseInt(trimmedResult);
         if (total == null) {
             return 0;
         } else if (res < 0) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditLabCommand.MESSAGE_USAGE));
+            throw new ParseException(Lab.MESSAGE_LAB_SCORE_CONSTRAINT);
         }
         return Integer.parseInt(total.trim());
     }

--- a/src/main/java/seedu/programmer/model/student/Lab.java
+++ b/src/main/java/seedu/programmer/model/student/Lab.java
@@ -4,7 +4,10 @@ import static java.util.Objects.requireNonNull;
 
 public class Lab implements DisplayableObject {
 
-    public static final String LAB_SCORE_MESSAGE_CONSTRAINTS = "The total score should be a positive value.";
+    public static final String MESSAGE_LAB_SCORE_AND_LAB_NUMBER_REQUIREMENT =
+            "Both Lab Number and Score to be inputted should be provided.";
+    public static final String MESSAGE_LAB_NUMBER_CONSTRAINT = "Lab number should be a non-negative integer.";
+    public static final String MESSAGE_LAB_SCORE_CONSTRAINT = "Lab score should be a non-negative integer.";
 
     private int labNum;
     private Integer actualScore;

--- a/src/test/java/seedu/programmer/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/programmer/logic/parser/EditCommandParserTest.java
@@ -2,6 +2,7 @@
 package seedu.programmer.logic.parser;
 
 import static seedu.programmer.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.programmer.commons.core.Messages.MESSAGE_TEMPLATE;
 import static seedu.programmer.logic.commands.CommandTestUtil.CLASS_ID_DESC_AMY;
 import static seedu.programmer.logic.commands.CommandTestUtil.CLASS_ID_DESC_BOB;
 import static seedu.programmer.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
@@ -22,6 +23,8 @@ import static seedu.programmer.logic.commands.CommandTestUtil.VALID_STUDENT_ID_A
 import static seedu.programmer.logic.commands.CommandTestUtil.VALID_STUDENT_ID_BOB;
 import static seedu.programmer.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.programmer.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.programmer.logic.parser.ParserUtil.MESSAGE_EMPTY_INDEX;
+import static seedu.programmer.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
 import static seedu.programmer.testutil.TypicalIndexes.INDEX_FIRST_STUDENT;
 import static seedu.programmer.testutil.TypicalIndexes.INDEX_SECOND_STUDENT;
 import static seedu.programmer.testutil.TypicalIndexes.INDEX_THIRD_STUDENT;
@@ -48,53 +51,65 @@ public class EditCommandParserTest {
     @Test
     public void parse_missingParts_failure() {
         // no index specified
-        assertParseFailure(parser, VALID_NAME_AMY, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, VALID_NAME_AMY,
+                String.format(MESSAGE_TEMPLATE, MESSAGE_INVALID_INDEX, EditCommand.MESSAGE_USAGE));
 
         // no field specified
-        assertParseFailure(parser, "1", EditCommand.MESSAGE_NOT_EDITED);
+        assertParseFailure(parser, "1",
+                String.format(MESSAGE_TEMPLATE, EditCommand.MESSAGE_NOT_EDITED, EditCommand.MESSAGE_USAGE));
 
         // no index and no field specified
-        assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "",
+                String.format(MESSAGE_TEMPLATE, MESSAGE_EMPTY_INDEX, EditCommand.MESSAGE_USAGE));
     }
 
     @Test
     public void parse_invalidPreamble_failure() {
         // negative index
-        assertParseFailure(parser, "-5" + NAME_DESC_AMY, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "-5" + NAME_DESC_AMY,
+                String.format(MESSAGE_TEMPLATE, MESSAGE_INVALID_INDEX, EditCommand.MESSAGE_USAGE));
 
         // zero index
-        assertParseFailure(parser, "0" + NAME_DESC_AMY, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "0" + NAME_DESC_AMY,
+                String.format(MESSAGE_TEMPLATE, MESSAGE_INVALID_INDEX, EditCommand.MESSAGE_USAGE));
 
         // invalid arguments being parsed as preamble
-        assertParseFailure(parser, "1 some random string", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "1 some random string",
+                String.format(MESSAGE_TEMPLATE, MESSAGE_INVALID_INDEX, EditCommand.MESSAGE_USAGE));
 
         // invalid prefix being parsed as preamble
-        assertParseFailure(parser, "1 i/ string", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "1 i/ string",
+                String.format(MESSAGE_TEMPLATE, MESSAGE_INVALID_INDEX, EditCommand.MESSAGE_USAGE));
     }
 
     @Test
     public void parse_invalidValue_failure() {
         // invalid name
-        assertParseFailure(parser, "1" + INVALID_NAME_DESC, Name.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, "1" + INVALID_NAME_DESC,
+                String.format(MESSAGE_TEMPLATE, Name.MESSAGE_CONSTRAINTS, EditCommand.MESSAGE_USAGE));
         // invalid student_id
-        assertParseFailure(parser, "1" + INVALID_STUDENT_ID_DESC, StudentId.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, "1" + INVALID_STUDENT_ID_DESC,
+                String.format(MESSAGE_TEMPLATE, StudentId.MESSAGE_CONSTRAINTS, EditCommand.MESSAGE_USAGE));
         // invalid class_id
-        assertParseFailure(parser, "1" + INVALID_CLASS_ID_DESC, ClassId.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, "1" + INVALID_CLASS_ID_DESC,
+                String.format(MESSAGE_TEMPLATE, ClassId.MESSAGE_CONSTRAINTS, EditCommand.MESSAGE_USAGE));
         // invalid email
-        assertParseFailure(parser, "1" + INVALID_EMAIL_DESC, Email.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, "1" + INVALID_EMAIL_DESC,
+                String.format(MESSAGE_TEMPLATE, Email.MESSAGE_CONSTRAINTS, EditCommand.MESSAGE_USAGE));
 
         // invalid studentId followed by valid classid
         assertParseFailure(parser, "1" + INVALID_STUDENT_ID_DESC + CLASS_ID_DESC_AMY,
-                StudentId.MESSAGE_CONSTRAINTS);
+                String.format(MESSAGE_TEMPLATE, StudentId.MESSAGE_CONSTRAINTS, EditCommand.MESSAGE_USAGE));
 
         // valid studentId followed by invalid studentId. The test case for invalid studentId followed by valid
         // studentId is tested at {@code parse_invalidValueFollowedByValidValue_success()}
         assertParseFailure(parser, "1" + STUDENT_ID_DESC_BOB + INVALID_STUDENT_ID_DESC,
-                StudentId.MESSAGE_CONSTRAINTS);
+                String.format(MESSAGE_TEMPLATE, StudentId.MESSAGE_CONSTRAINTS, EditCommand.MESSAGE_USAGE));
 
         // multiple invalid values, but only the first invalid value is captured
         assertParseFailure(parser, "1" + INVALID_NAME_DESC + INVALID_STUDENT_ID_DESC
-                        + VALID_CLASS_ID_AMY + VALID_STUDENT_ID_AMY, Name.MESSAGE_CONSTRAINTS);
+                        + VALID_CLASS_ID_AMY + VALID_STUDENT_ID_AMY,
+                String.format(MESSAGE_TEMPLATE, Name.MESSAGE_CONSTRAINTS, EditCommand.MESSAGE_USAGE));
     }
 
     @Test

--- a/src/test/java/seedu/programmer/logic/parser/EditLabCommandParserTest.java
+++ b/src/test/java/seedu/programmer/logic/parser/EditLabCommandParserTest.java
@@ -2,7 +2,7 @@
 package seedu.programmer.logic.parser;
 
 import static seedu.programmer.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.programmer.commons.core.Messages.MESSAGE_MISSING_ARGUMENT;
+import static seedu.programmer.commons.core.Messages.MESSAGE_TEMPLATE;
 import static seedu.programmer.logic.commands.CommandTestUtil.INVALID_LAB_NUM;
 import static seedu.programmer.logic.commands.CommandTestUtil.INVALID_LAB_TOTAL;
 import static seedu.programmer.logic.commands.CommandTestUtil.INVALID_NEW_LAB_NUM;
@@ -16,6 +16,8 @@ import static seedu.programmer.logic.commands.CommandTestUtil.VALID_TOTAL_SCORE;
 import static seedu.programmer.logic.commands.CommandTestUtil.VALID_TOTAL_SCORE2;
 import static seedu.programmer.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.programmer.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.programmer.model.student.Lab.MESSAGE_LAB_NUMBER_CONSTRAINT;
+import static seedu.programmer.model.student.Lab.MESSAGE_LAB_SCORE_CONSTRAINT;
 
 import org.junit.jupiter.api.Test;
 
@@ -35,7 +37,7 @@ public class EditLabCommandParserTest {
         // missing labNum prefix
         assertParseFailure(parser,
                 VALID_LAB_NO + NEW_LAB_NUM + LAB_TOTAL2,
-                String.format(MESSAGE_MISSING_ARGUMENT, EditLabCommand.MESSAGE_USAGE));
+                MESSAGE_INVALID_FORMAT);
     }
 
     @Test
@@ -43,17 +45,17 @@ public class EditLabCommandParserTest {
         // invalid labNum
         assertParseFailure(parser,
                 INVALID_LAB_NUM + NEW_LAB_NUM + LAB_TOTAL2,
-                MESSAGE_INVALID_FORMAT);
+                String.format(MESSAGE_TEMPLATE, MESSAGE_LAB_NUMBER_CONSTRAINT, EditLabCommand.MESSAGE_USAGE));
 
         // invalid newLabNum
         assertParseFailure(parser,
                 LAB_NUM + INVALID_NEW_LAB_NUM + LAB_TOTAL2,
-                MESSAGE_INVALID_FORMAT);
+                String.format(MESSAGE_TEMPLATE, MESSAGE_LAB_NUMBER_CONSTRAINT, EditLabCommand.MESSAGE_USAGE));
 
         // invalid labTotal
         assertParseFailure(parser,
                 LAB_NUM + NEW_LAB_NUM + INVALID_LAB_TOTAL,
-                MESSAGE_INVALID_FORMAT);
+                String.format(MESSAGE_TEMPLATE, MESSAGE_LAB_SCORE_CONSTRAINT, EditLabCommand.MESSAGE_USAGE));
     }
 
     @Test


### PR DESCRIPTION
fixes #349 

Ensure that error messages are displayed accordingly and in detail instead of a general statement when edit command is being executed.

Certain edits are also made to `EditLabCommandParser` and `AddLabCommandParser` as changes were made to the exception checking in `ParserUtil` for lab number, lab score and lab total.