### PR TITLE
Fix #455: JsonAdaptedLab

### DIFF
--- a/src/main/java/seedu/programmer/model/student/Lab.java
+++ b/src/main/java/seedu/programmer/model/student/Lab.java
@@ -65,12 +65,12 @@ public class Lab implements DisplayableObject {
         return labNum.getLabNum();
     }
 
-    public String getLabResultValue() {
-        return actualScore.toString();
+    public int getLabResultValue() {
+        return actualScore.getLabResult();
     }
 
-    public String getLabTotalValue() {
-        return totalScore.toString();
+    public int getLabTotalValue() {
+        return totalScore.getLabTotalScore();
     }
 
     public void updateActualScore(LabResult value) {

--- a/src/main/java/seedu/programmer/storage/JsonAdaptedLab.java
+++ b/src/main/java/seedu/programmer/storage/JsonAdaptedLab.java
@@ -8,17 +8,17 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import seedu.programmer.model.student.Lab;
 
 public class JsonAdaptedLab {
-    private String labNumValue;
-    private String actualScoreValue;
-    private String totalScoreValue;
+    private final int labNumValue;
+    private final int actualScoreValue;
+    private final int totalScoreValue;
 
     /**
      * Constructs a {@code JsonAdaptedLab} with the given lab details.
      */
     @JsonCreator
-    public JsonAdaptedLab(@JsonProperty("labNumValue") String labNumValue,
-                          @JsonProperty("actualScoreValue") String actualScoreValue,
-                          @JsonProperty("totalScoreValue") String totalScoreValue) {
+    public JsonAdaptedLab(@JsonProperty("labNumValue") int labNumValue,
+                          @JsonProperty("actualScoreValue") int actualScoreValue,
+                          @JsonProperty("totalScoreValue") int totalScoreValue) {
         this.labNumValue = labNumValue;
         this.actualScoreValue = actualScoreValue;
         this.totalScoreValue = totalScoreValue;
@@ -30,32 +30,20 @@ public class JsonAdaptedLab {
      */
     public JsonAdaptedLab(Lab lab) {
         requireNonNull(lab);
-        this.labNumValue = String.valueOf(lab.getLabNumValue());
+        this.labNumValue = lab.getLabNumValue();
         this.actualScoreValue = lab.getLabResultValue();
         this.totalScoreValue = lab.getLabTotalValue();
     }
 
-    public String getLabNumValue() {
+    public Integer getLabNum() {
         return labNumValue;
     }
 
-    public String getLabResultValue() {
+    public Integer getLabResult() {
         return actualScoreValue;
     }
 
-    public String getLabTotalValue() {
-        return totalScoreValue;
-    }
-
-    public Integer getLabNum() {
-        return Integer.parseInt(labNumValue);
-    }
-
-    public Integer getLabResult() {
-        return Integer.parseInt(actualScoreValue);
-    }
-
     public Integer getLabTotal() {
-        return Integer.parseInt(totalScoreValue);
+        return totalScoreValue;
     }
 }

--- a/src/main/java/seedu/programmer/storage/JsonAdaptedLab.java
+++ b/src/main/java/seedu/programmer/storage/JsonAdaptedLab.java
@@ -31,7 +31,7 @@ public class JsonAdaptedLab {
     public JsonAdaptedLab(Lab lab) {
         requireNonNull(lab);
         this.labNumValue = lab.getLabNumValue();
-        this.actualScoreValue = lab.getLabResultValue();
+        this.actualScoreValue = lab.getLabResultValue() == -1 ? 0 : lab.getLabTotalValue();
         this.totalScoreValue = lab.getLabTotalValue();
     }
 


### PR DESCRIPTION
Fix #460 Repost as files changed was not accurate.

Note:
When labs are unmarked, student's lab score will be recorded as 0. (i.e. if a lab is unmarked, we can assume that their score for that lab is 0.)
The alternative (i.e. storing the default lab score of -1) would result in a skewed grade distribution on Luminus should the lab results be uploaded there (which is the expected use case of the Download feature)