### PR TITLE
Fix the bug that Lab0 is allowed when user manually delete the labNumber attribute in json file

### DIFF
--- a/src/main/java/seedu/programmer/logic/commands/EditLabCommand.java
+++ b/src/main/java/seedu/programmer/logic/commands/EditLabCommand.java
@@ -57,7 +57,7 @@ public class EditLabCommand extends Command {
     public EditLabCommand(Lab original, LabTotal total) {
         this.original = original;
         this.total = total;
-        this.newLabNum = new LabNum(0);
+        this.newLabNum = new LabNum(original.getLabNumValue());
     }
 
     /**
@@ -81,7 +81,8 @@ public class EditLabCommand extends Command {
         }
         Lab newLab = new Lab(newLabNum);
 
-        if (studentList.get(0).getLabList().contains(newLab)) {
+        if (original.getLabTotal() != null && original.getLabTotal().equals(total)
+                && studentList.get(0).getLabList().contains(newLab)) {
             throw new CommandException(String.format(Lab.MESSAGE_LAB_ALREADY_EXISTS, newLab));
         }
 

--- a/src/main/java/seedu/programmer/model/student/Lab.java
+++ b/src/main/java/seedu/programmer/model/student/Lab.java
@@ -8,7 +8,8 @@ public class Lab implements DisplayableObject {
             "Both Lab Number and Score to be should be provided together.";
     public static final String MESSAGE_LAB_NUMBER_CONSTRAINT =
             "Lab number should be between 1 and 13 (inclusive).";
-    public static final String MESSAGE_LAB_SCORE_CONSTRAINT = "Lab score should be a non-negative integer or a unmarked placeholder(-1).";
+    public static final String MESSAGE_LAB_SCORE_CONSTRAINT = "Lab score should be a non-negative integer or " +
+            "a unmarked placeholder(-1).";
     public static final String MESSAGE_LAB_TOTAL_SCORE_CONSTRAINT =
             "Lab total score should be between 1 and 100 (inclusive)";
 

--- a/src/main/java/seedu/programmer/model/student/Lab.java
+++ b/src/main/java/seedu/programmer/model/student/Lab.java
@@ -8,7 +8,7 @@ public class Lab implements DisplayableObject {
             "Both Lab Number and Score to be should be provided together.";
     public static final String MESSAGE_LAB_NUMBER_CONSTRAINT =
             "Lab number should be between 1 and 13 (inclusive).";
-    public static final String MESSAGE_LAB_SCORE_CONSTRAINT = "Lab score should be a non-negative integer.";
+    public static final String MESSAGE_LAB_SCORE_CONSTRAINT = "Lab score should be a non-negative integer or a unmarked placeholder(-1).";
     public static final String MESSAGE_LAB_TOTAL_SCORE_CONSTRAINT =
             "Lab total score should be between 1 and 100 (inclusive)";
 

--- a/src/main/java/seedu/programmer/model/student/LabNum.java
+++ b/src/main/java/seedu/programmer/model/student/LabNum.java
@@ -28,7 +28,7 @@ public class LabNum {
      * Returns true if a given string is a valid labNum.
      */
     public static boolean isValidLabNum (Integer test) {
-        return test.compareTo(0) >= 0 && test.compareTo(14) < 0;
+        return test.compareTo(0) > 0 && test.compareTo(14) < 0;
     }
 
     @Override


### PR DESCRIPTION
If user deletes a Lab's LabNumber in json file now and restart the app, the app will still accept the json file and display Lab0 as a tag, which is an unexpected behaviour. 

This fix prevents the above to happen and start with an empty ProgrammerError instead.