### PR TITLE
Fix the bug that Lab0 is allowed when user manually delete the labNumber attribute in json file.

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -22,6 +22,7 @@ classes. If you are familiar with Unix commands, this is definitely for you!
       2. [Purge All Data: `purge`](#purge-all-data)
       3. [Upload Data: `upload`](#upload-data)
       4. [Download Data: `download`](#download-data)
+      5. [Edit The Data File Directly (For advanced users)](#edit-data-file)
   4. [Student Features](#student-features)
       1. [Add Student: `add`](#add-student)
       2. [Edit Student Details: `edit`](#edit-student)
@@ -161,6 +162,28 @@ In summary:
 
 Downloads the student data to a CSV file in the chosen directory. The file will be automatically named `programmerError.csv`.
 
+### <a name="edit-data-file"></a>2.4 Edit The Data File Directly (For advanced users)
+
+Instead of using commands to edit students' details and lab results, you may change the json file directly.
+
+Note that ProgrammerError will only accept data files fulfilling the restrictions specified in the [parameter summary](#parameter-summary).
+The absence of an attribute and/or invalid value for an attribute will result in an error message shown in the logger, and ProgrammerError 
+will start with an empty json data file instead. 
+
+Here are some examples of corrupted data that is not accepted by ProgrammerError.
+
+     "labResultList" : [ {
+      //Absent attribute example: LabNumValue attribute is missing
+      "actualScoreValue" : 10,
+      "totalScoreValue" : 20
+      }
+
+     "labResultList" : [ {
+      //Invalid attribute example: LabNumValue is not between 1 to 13
+      "labNumValue" : 20,
+      "actualScoreValue" : 15,
+      "totalScoreValue" : 20
+      }
 
 ## <a name="student-features"></a>3. Student Features
 

--- a/src/main/java/seedu/programmer/model/student/LabNum.java
+++ b/src/main/java/seedu/programmer/model/student/LabNum.java
@@ -28,7 +28,7 @@ public class LabNum {
      * Returns true if a given string is a valid labNum.
      */
     public static boolean isValidLabNum (Integer test) {
-        return test.compareTo(0) >= 0 && test.compareTo(14) < 0;
+        return test.compareTo(0) > 0 && test.compareTo(14) < 0;
     }
 
     @Override

--- a/src/main/java/seedu/programmer/storage/JsonAdaptedStudent.java
+++ b/src/main/java/seedu/programmer/storage/JsonAdaptedStudent.java
@@ -115,7 +115,7 @@ class JsonAdaptedStudent {
                 int labTotal = adaptedLab.getLabTotal();
 
 
-                if (!LabNum.isValidLabNum(labNum)) {
+                if (!LabNum.isValidLabNum(labNum) || labNum == 0) {
                     throw new IllegalValueException(Lab.MESSAGE_LAB_NUMBER_CONSTRAINT);
                 }
 

--- a/src/main/java/seedu/programmer/storage/JsonAdaptedStudent.java
+++ b/src/main/java/seedu/programmer/storage/JsonAdaptedStudent.java
@@ -115,7 +115,7 @@ class JsonAdaptedStudent {
                 int labTotal = adaptedLab.getLabTotal();
 
 
-                if (!LabNum.isValidLabNum(labNum) || labNum == 0) {
+                if (!LabNum.isValidLabNum(labNum)) {
                     throw new IllegalValueException(Lab.MESSAGE_LAB_NUMBER_CONSTRAINT);
                 }
 


### PR DESCRIPTION
If user deletes a Lab's LabNumber in json file now and restart the app, the app will still accept the json file and display Lab0 as a tag, which is an unexpected behaviour.

This fix prevents the above to happen and start with an empty ProgrammerError instead.